### PR TITLE
hal: telink: BLE PM improvements

### DIFF
--- a/tlsr9/CMakeLists.txt
+++ b/tlsr9/CMakeLists.txt
@@ -65,6 +65,7 @@ zephyr_library_sources_ifdef(CONFIG_USB_TELINK_B91 drivers/B91/usbhw.c)
 #PM driver dependency
 zephyr_library_sources_ifdef(CONFIG_PM drivers/B91/stimer.c)
 zephyr_library_sources_ifdef(CONFIG_PM drivers/B91/pm.c)
+zephyr_library_sources_ifdef(CONFIG_PM common/b91_sleep.c)
 
 # BLE reference sources
 if (CONFIG_BT_B91)

--- a/tlsr9/ble/stack/ble/controller/os_sup.h
+++ b/tlsr9/ble/stack/ble/controller/os_sup.h
@@ -1,0 +1,34 @@
+/******************************************************************************
+ * Copyright (c) 2023 Telink Semiconductor (Shanghai) Co., Ltd. ("TELINK")
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *****************************************************************************/
+
+#ifndef _OS_SUP_H_
+#define _OS_SUP_H_
+
+#include "stack/ble/ble_config.h"
+
+typedef void (*os_give_sem_t)(void);
+
+/* User API */
+extern void blc_ll_registerGiveSemCb(os_give_sem_t func);
+extern int blc_pm_handler(void);
+extern void blc_pm_setAppWakeupLowPower(u32 wakeup_tick, u8 enable);
+
+/* Stack API. !!! user can't use. */
+extern void blt_ll_sem_give(void);
+
+#endif /* _OS_SUP_H_ */

--- a/tlsr9/common/b91_sleep.c
+++ b/tlsr9/common/b91_sleep.c
@@ -1,0 +1,43 @@
+/******************************************************************************
+ * Copyright (c) 2023 Telink Semiconductor (Shanghai) Co., Ltd. ("TELINK")
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *****************************************************************************/
+#include "b91_sleep.h"
+#include <ext_driver/ext_pm.h>
+#include <stack/ble/controller/os_sup.h>
+
+/**
+ * @brief     This function sets B91 MCU to suspend mode
+ * @param[in] wake_stimer_tick - wake-up stimer tick
+ * @return    true if suspend mode entered otherwise false
+ */
+bool b91_suspend(uint32_t wake_stimer_tick)
+{
+	bool result = false;
+
+#if CONFIG_BT
+	blc_pm_setAppWakeupLowPower(wake_stimer_tick, 1);
+	if (!blc_pm_handler()) {
+		result = true;
+	}
+	blc_pm_setAppWakeupLowPower(0, 0);
+#else
+	cpu_sleep_wakeup_32k_rc(SUSPEND_MODE, PM_WAKEUP_TIMER, wake_stimer_tick);
+	result = true;
+#endif /* CONFIG_BT */
+
+	return result;
+}

--- a/tlsr9/common/b91_sleep.h
+++ b/tlsr9/common/b91_sleep.h
@@ -1,0 +1,35 @@
+/******************************************************************************
+ * Copyright (c) 2023 Telink Semiconductor (Shanghai) Co., Ltd. ("TELINK")
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *****************************************************************************/
+
+/********************************************************************************************************
+ * @file	b91_sleep.h
+ *
+ * @brief	This is the header file for B91
+ *
+ * @author	Driver Group
+ *
+ *******************************************************************************************************/
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifndef __B91_SLEEP_H
+#define __B91_SLEEP_H
+
+bool b91_suspend(uint32_t wake_stimer_tick);
+
+#endif /* __B91_SLEEP_H */

--- a/tlsr9/drivers/B91/flash.c
+++ b/tlsr9/drivers/B91/flash.c
@@ -32,10 +32,6 @@
 #include "core.h"
 #include "stimer.h"
 
-#if (CONFIG_BT_B91)
-#include "stack/ble/controller/ble_controller.h"
-#endif /* CONFIG_BT_B91 */
-
 #define DISABLE_BTB     __asm__("csrci 	0x7D0,8")
 #define ENABLE_BTB      __asm__("csrsi 	0x7D0,8")
 
@@ -117,9 +113,6 @@ _attribute_ram_code_sec_noinline_ static void flash_wait_done(void)
 			flash_cnt++;
 			break;
 		}
-#if (CONFIG_BT_B91)
-		blc_sdk_irq_handler();
-#endif /* CONFIG_BT_B91 */
 	}
 	mspi_high();
 }

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -4,10 +4,10 @@ build:
   kconfig: Kconfig
 blobs:
   - path: liblt_9518_zephyr.a
-    sha256: c863feadbd25d6c6d6e2506554740b57d079fe22706eb768d5ee1088d4940019
+    sha256: c3deb57096c4df1ef0a36e9e9d3c9d844f069967896a659ad474c90c514dcca0
     type: lib
-    version: 'V4.0.1.0_Patch_0001'
+    version: 'V4.0.1.0_Patch_0002'
     license-path: tlsr9/ble/license.txt
-    url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/raw/464d3e32e7195742adcc8a5dc282912b8ee8be0a/liblt_9518_zephyr.a
+    url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/raw/5d965f8b4ea26fbc1f14140fb2ecf76344580c4c/liblt_9518_zephyr.a
     description: "Binary libraries supporting Telink B91 series BLE subsystems"
-    doc-url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/blob/464d3e32e7195742adcc8a5dc282912b8ee8be0a/README.md
+    doc-url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/blob/5d965f8b4ea26fbc1f14140fb2ecf76344580c4c/README.md


### PR DESCRIPTION
- Switch off unused GPIO
- Allow BLE stack to control entering suspend mode

Co-authored-by: Andrii Bilynskyi <andrii.bilynskyi@telink-semi.com>

Signed-off-by: Qiu Gao <qiu.gao@telink-semi.com>