### PR TITLE
drivers: i2c: unified I2C driver to B9x-series

### DIFF
--- a/tlsr9/CMakeLists.txt
+++ b/tlsr9/CMakeLists.txt
@@ -67,7 +67,7 @@ zephyr_library_sources_ifdef(CONFIG_PWM_TELINK_B9X drivers/${SOC}/pwm.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_TELINK_B91 drivers/${SOC}/gpio.c)
 
 # I2C driver reference sources
-zephyr_library_sources_ifdef(CONFIG_I2C_TELINK_B91 drivers/${SOC}/i2c.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_TELINK_B9X drivers/${SOC}/i2c.c)
 
 # RF driver reference sources
 if(CONFIG_BT_B91 OR CONFIG_IEEE802154_TELINK_B91)


### PR DESCRIPTION
Adopted I2C driver for B92 board, B9x-series
will use the same Zephyr API driver from now