### PR TITLE
HAL: Telink: drivers: clock: Updated PLL according to the datasheet

### DIFF
--- a/tlsr9/drivers/B91/clock.h
+++ b/tlsr9/drivers/B91/clock.h
@@ -51,9 +51,10 @@
 #define  	CCLK_16M_HCLK_16M_PCLK_16M		clock_init(PLL_CLK_48M, PAD_PLL_DIV, PLL_DIV3_TO_CCLK, CCLK_DIV1_TO_HCLK, HCLK_DIV1_TO_PCLK, CCLK_TO_MSPI_CLK)
 #define		CCLK_24M_HCLK_24M_PCLK_24M		clock_init(PLL_CLK_48M, PAD_PLL_DIV, PLL_DIV2_TO_CCLK, CCLK_DIV1_TO_HCLK, HCLK_DIV1_TO_PCLK, CCLK_TO_MSPI_CLK)
 #define		CCLK_32M_HCLK_32M_PCLK_16M		clock_init(PLL_CLK_96M, PAD_PLL_DIV, PLL_DIV3_TO_CCLK, CCLK_DIV1_TO_HCLK, HCLK_DIV2_TO_PCLK, CCLK_TO_MSPI_CLK)
-#define		CCLK_48M_HCLK_48M_PCLK_24M		clock_init(PLL_CLK_48M, PAD_PLL, /*not affected*/PLL_DIV4_TO_CCLK, CCLK_DIV1_TO_HCLK, HCLK_DIV2_TO_PCLK, CCLK_TO_MSPI_CLK)
-#define 	CCLK_60M_HCLK_30M_PCLK_15M		clock_init(PLL_CLK_60M, PAD_PLL, /*not affected*/PLL_DIV3_TO_CCLK, CCLK_DIV2_TO_HCLK, HCLK_DIV2_TO_PCLK, CCLK_TO_MSPI_CLK)
-#define 	CCLK_96M_HCLK_48M_PCLK_24M		clock_init(PLL_CLK_96M, PAD_PLL, /*not affected*/PLL_DIV2_TO_CCLK, CCLK_DIV2_TO_HCLK, HCLK_DIV2_TO_PCLK, PLL_DIV2_TO_MSPI_CLK)
+#define		CCLK_48M_HCLK_48M_PCLK_24M		clock_init(PLL_CLK_96M, PAD_PLL_DIV, PLL_DIV2_TO_CCLK, CCLK_DIV1_TO_HCLK, HCLK_DIV2_TO_PCLK, CCLK_TO_MSPI_CLK)
+#define 	CCLK_60M_HCLK_30M_PCLK_15M		clock_init(PLL_CLK_120M, PAD_PLL_DIV, PLL_DIV2_TO_CCLK, CCLK_DIV2_TO_HCLK, HCLK_DIV2_TO_PCLK, CCLK_TO_MSPI_CLK)
+#define 	CCLK_96M_HCLK_48M_PCLK_24M		clock_init(PLL_CLK_192M, PAD_PLL_DIV, PLL_DIV2_TO_CCLK, CCLK_DIV2_TO_HCLK, HCLK_DIV2_TO_PCLK, PLL_DIV4_TO_MSPI_CLK)
+/*using the 96 MHz core clock (PLL > 120MHz) can cause the hang during PLL lock after CPU Wakeup after PM mode*/
 /**********************************************************************************************************************
  *                                         global data type                                                           *
  *********************************************************************************************************************/


### PR DESCRIPTION
Fixed the PLL clocks due to datasheet mistake