### PR TITLE
hal: telink: Fix retention for B92

### DIFF
--- a/tlsr9/common/sleep.c
+++ b/tlsr9/common/sleep.c
@@ -27,6 +27,12 @@
 #include <b9x_bt.h>
 #endif /* CONFIG_BT_B9X */
 
+#if CONFIG_BOARD_TLSR9518ADK80D_RETENTION
+#define DEEPSLEEP_MODE_RET_SRAM DEEPSLEEP_MODE_RET_SRAM_LOW64K
+#elif CONFIG_BOARD_TLSR9528A_RETENTION
+#define DEEPSLEEP_MODE_RET_SRAM DEEPSLEEP_MODE_RET_SRAM_LOW96K
+#endif
+
 /**
  * @brief     This function sets B9X MCU to suspend mode
  * @param[in] wake_stimer_tick - wake-up stimer tick
@@ -89,7 +95,7 @@ bool b9x_deep_sleep(uint32_t wake_stimer_tick)
 		tl_context_save();
 		if (!tl_sleep_retention) {
 			tl_sleep_retention = true;
-			(void)cpu_sleep_wakeup_32k_rc(DEEPSLEEP_MODE_RET_SRAM_LOW64K,
+			(void)cpu_sleep_wakeup_32k_rc(DEEPSLEEP_MODE_RET_SRAM,
 				PM_WAKEUP_TIMER | PM_WAKEUP_PAD,
 				wake_stimer_tick);
 			tl_sleep_retention = false;
@@ -103,7 +109,7 @@ bool b9x_deep_sleep(uint32_t wake_stimer_tick)
 	tl_context_save();
 	if (!tl_sleep_retention) {
 		tl_sleep_retention = true;
-		(void)cpu_sleep_wakeup_32k_rc(DEEPSLEEP_MODE_RET_SRAM_LOW64K,
+		(void)cpu_sleep_wakeup_32k_rc(DEEPSLEEP_MODE_RET_SRAM,
 			PM_WAKEUP_TIMER | PM_WAKEUP_PAD,
 			wake_stimer_tick);
 		tl_sleep_retention = false;

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -8,15 +8,15 @@ blobs:
     type: lib
     version: 'V4.0.1.0_Patch_0003'
     license-path: tlsr9/ble/license.txt
-    url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/raw/cb62c1ab79274a67c228f26a811e738d05a444b6/liblt_9518_zephyr.a
+    url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/raw/9a45494713524fe8ad3b5f98b7606e39c8d82517/liblt_9518_zephyr.a
     description: "Binary libraries supporting Telink B91 series BLE subsystems"
-    doc-url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/blob/cb62c1ab79274a67c228f26a811e738d05a444b6/README.md
+    doc-url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/blob/9a45494713524fe8ad3b5f98b7606e39c8d82517/README.md
 
   - path: liblt_9528_zephyr.a
-    sha256: 578d2629267f23d82198f21780981b7e72693a0d05f7b73410d4b007f359ee49
+    sha256: 0b30dc56fbdada609d2ad8481563c41da3857190582b6d65f6310053110fec02
     type: lib
-    version: 'V4.0.1.0_Patch_0003'
+    version: 'V4.0.1.0_Patch_0004'
     license-path: tlsr9/ble/license.txt
-    url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/raw/cb62c1ab79274a67c228f26a811e738d05a444b6/liblt_9528_zephyr.a
+    url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/raw/9a45494713524fe8ad3b5f98b7606e39c8d82517/liblt_9528_zephyr.a
     description: "Binary libraries supporting Telink B92 series BLE subsystems"
-    doc-url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/blob/cb62c1ab79274a67c228f26a811e738d05a444b6/README.md
+    doc-url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/blob/9a45494713524fe8ad3b5f98b7606e39c8d82517/README.md


### PR DESCRIPTION
Updated retention memory amount. Updated BLE library.