### PR TITLE
Fix BT buffers

### DIFF
--- a/tlsr9/ble/vendor/controller/b9x_bt_buffer.h
+++ b/tlsr9/ble/vendor/controller/b9x_bt_buffer.h
@@ -26,6 +26,8 @@
 #include "stack/ble/B92/ble.h"
 #endif
 
+#define BT_BUF_HCI_RX_SIZE                                                                             \
+        MAX(BT_BUF_CMD_SIZE(CONFIG_BT_BUF_CMD_TX_SIZE), BT_BUF_ACL_SIZE(CONFIG_BT_BUF_ACL_TX_SIZE))
 
 #define ACL_CONN_MAX_RX_OCTETS (BT_BUF_RX_SIZE > 251 ? 251 : BT_BUF_RX_SIZE)
 #define ACL_SLAVE_MAX_TX_OCTETS (CONFIG_BT_BUF_ACL_TX_SIZE > 251 ? 251 : CONFIG_BT_BUF_ACL_TX_SIZE)
@@ -58,7 +60,7 @@
     TX from host CMD or ACL buffer, RX to Contorller HCI buffer
     According to Telink implementatios, the buffer shall be alligned to 16.
 */
-#define HCI_RX_FIFO_SIZE HCI_FIFO_SIZE(BT_BUF_TX_SIZE)
+#define HCI_RX_FIFO_SIZE HCI_FIFO_SIZE(BT_BUF_HCI_RX_SIZE)
 
 /*
     According to Telink implementation shall number of buffers shall be power of 2
@@ -80,7 +82,7 @@
     Intermediate ACL buffer that takes data from HCI RX and pass it to ACL TX
     According to Telink implementatios, the buffer shall be alligned to 4.
 */
-#define HCI_RX_ACL_FIFO_SIZE ALIGN(BT_BUF_ACL_SIZE(ACL_CONN_MAX_RX_OCTETS), ALIGN_4)
+#define HCI_RX_ACL_FIFO_SIZE ALIGN(BT_BUF_ACL_SIZE(BT_BUF_TX_SIZE), ALIGN_4)
 
 /*
     According to Telink implementation shall number of buffers shall be power of 2

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -4,19 +4,19 @@ build:
   kconfig: Kconfig
 blobs:
   - path: liblt_9518_zephyr.a
-    sha256: c80cbd4304802f25cc86fc41a3e420d9aba9cba3932ed9338d9059ec5b15de6d
+    sha256: 9b4a4c98734ac953f5ea4499763bfb5bba0a682390b2a01f4b8c068dfb0fee7f
     type: lib
-    version: 'V4.0.1.0_Patch_0003'
+    version: 'V4.0.1.0_Patch_0004'
     license-path: tlsr9/ble/license.txt
-    url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/raw/9a45494713524fe8ad3b5f98b7606e39c8d82517/liblt_9518_zephyr.a
+    url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/raw/a064cf6f8bcb37042dbb7be841933b86e4d095ae/liblt_9518_zephyr.a
     description: "Binary libraries supporting Telink B91 series BLE subsystems"
-    doc-url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/blob/9a45494713524fe8ad3b5f98b7606e39c8d82517/README.md
+    doc-url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/blob/a064cf6f8bcb37042dbb7be841933b86e4d095ae/README.md
 
   - path: liblt_9528_zephyr.a
     sha256: 0b30dc56fbdada609d2ad8481563c41da3857190582b6d65f6310053110fec02
     type: lib
     version: 'V4.0.1.0_Patch_0004'
     license-path: tlsr9/ble/license.txt
-    url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/raw/9a45494713524fe8ad3b5f98b7606e39c8d82517/liblt_9528_zephyr.a
+    url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/raw/a064cf6f8bcb37042dbb7be841933b86e4d095ae/liblt_9528_zephyr.a
     description: "Binary libraries supporting Telink B92 series BLE subsystems"
-    doc-url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/blob/9a45494713524fe8ad3b5f98b7606e39c8d82517/README.md
+    doc-url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/blob/a064cf6f8bcb37042dbb7be841933b86e4d095ae/README.md


### PR DESCRIPTION
It is a partial revert of 604f2c3f7a650e8a0dd8d6e21a20c3432509e45f.

By replacing definition of BT_BUF_TX_SIZE in that commit a HCI_RX_FIFO_SIZE was unintentionally changed. It must stay as it was before in that case since it concerns TX buf size not only ACL, but also CMD buf size.

In case of HCI_RX_ACL_FIFO_SIZE it should have value of BT_BUF_TX_SIZE not ACL_CONN_MAX_RX_OCTETS, because previously it has value of CONFIG_BT_BUF_ACL_TX_SIZE that is completely another value.