### PR TITLE
hal: telink: Update B92 BLE library

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -13,10 +13,10 @@ blobs:
     doc-url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/blob/2c918ce4b8eaf336d5d560c3d1d04af351836d82/README.md
 
   - path: liblt_9528_zephyr.a
-    sha256: 756d51112bac3d7e0c0772e84cb5b0fd7f3af6683263a3206265a58e315bddf1
+    sha256: 8fdffe459bbf62ddb972be3f57f2eb3ab7df3db6fe764d9eff24466a46884725
     type: lib
-    version: 'V4.0.2.0_ER_patch_002'
+    version: 'V4.0.2.0_ER_patch_003'
     license-path: tlsr9/ble/license.txt
-    url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/raw/2c918ce4b8eaf336d5d560c3d1d04af351836d82/liblt_9528_zephyr.a
+    url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/raw/073f23f6cad15fd9ef371b5b9a8ec5627d7fbd3a/liblt_9528_zephyr.a
     description: "Binary libraries supporting Telink B92 series BLE subsystems"
-    doc-url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/blob/2c918ce4b8eaf336d5d560c3d1d04af351836d82/README.md
+    doc-url: https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/blob/073f23f6cad15fd9ef371b5b9a8ec5627d7fbd3a/README.md


### PR DESCRIPTION
- Move drivres ramcode into .ram_code linker section
- Move BLE stack ramcode into .ram_code_ble linker section