### PR TITLE
hal: telink: drivers: usb: fixed b95 endpoint switch

### DIFF
--- a/tlsr9/drivers/B95/usbhw.h
+++ b/tlsr9/drivers/B95/usbhw.h
@@ -337,7 +337,7 @@ static inline void usbhw_set_eps_en(usb_ep_en_e ep)
     }
     else
     {
-        reg_usb_edp_en = ep;
+        reg_usb_edp_en |= ep;
     }
 }
 


### PR DESCRIPTION
- fixed b95 endpoint switch