### PR TITLE
drivers: crypto: added crypto driver for B95

### DIFF
--- a/tlsr9/crypto/mbedtls/internal/compatibility/aes_alt.c
+++ b/tlsr9/crypto/mbedtls/internal/compatibility/aes_alt.c
@@ -53,6 +53,10 @@
 
 #include "../multithread.h"
 #include "aes.h"
+#if CONFIG_SOC_RISCV_TELINK_B95
+#include "ske.h"
+#include "ske_portable.h"
+#endif
 
 /* Parameter validation macros based on platform_util.h */
 #define AES_VALIDATE_RET( cond )    \
@@ -861,7 +865,13 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
 {
     if ( ctx->nr == 10 ) {
         mbedtls_aes_lock();
+#if CONFIG_SOC_RISCV_TELINK_B91 || CONFIG_SOC_RISCV_TELINK_B92
         ( void ) aes_encrypt( ( unsigned char * )ctx->buf, ( unsigned char * )input, output );
+#elif CONFIG_SOC_RISCV_TELINK_B95
+        ( void ) ske_lp_crypto(SKE_ALG_AES_128, SKE_MODE_ECB,
+	    SKE_CRYPTO_ENCRYPT, ( unsigned char * )ctx->buf, 0,
+        NULL, ( unsigned char * )input, output, 16 );
+#endif
         mbedtls_aes_unlock();
         return 0;
     }
@@ -932,7 +942,13 @@ int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
 {
     if ( ctx->nr == 10 ) {
         mbedtls_aes_lock();
+#if CONFIG_SOC_RISCV_TELINK_B91 || CONFIG_SOC_RISCV_TELINK_B92
         ( void ) aes_decrypt( ( unsigned char * )ctx->buf, ( unsigned char * )input, output );
+#elif CONFIG_SOC_RISCV_TELINK_B95
+        ( void ) ske_lp_crypto(SKE_ALG_AES_128, SKE_MODE_ECB,
+	    SKE_CRYPTO_DECRYPT, ( unsigned char * )ctx->buf, 0,
+        NULL, ( unsigned char * )input, output, 16 );
+#endif
         mbedtls_aes_unlock();
         return 0;
     }
@@ -1022,6 +1038,9 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
         // unaccelerated mode
         //
     }
+#endif
+#ifdef CONFIG_SOC_RISCV_TELINK_B95
+    ske_dig_en();
 #endif
 
     if( mode == MBEDTLS_AES_ENCRYPT )

--- a/tlsr9/crypto/mbedtls/internal/compatibility/ecp_alt.c
+++ b/tlsr9/crypto/mbedtls/internal/compatibility/ecp_alt.c
@@ -92,7 +92,9 @@
 /* HW accelerator functionality */
 extern int ecp_alt_b9x_backend_check_pubkey( const mbedtls_ecp_group *grp, const mbedtls_ecp_point *pt );
 extern int ecp_alt_b9x_backend_mul( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
-                                    const mbedtls_mpi *m, const mbedtls_ecp_point *P );
+                                    const mbedtls_mpi *m, const mbedtls_ecp_point *P,
+                                    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
+                                    mbedtls_ecp_restart_ctx *rs_ctx );
 extern int ecp_alt_b9x_backend_muladd( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
                                        const mbedtls_mpi *m, const mbedtls_ecp_point *P,
                                        const mbedtls_mpi *n, const mbedtls_ecp_point *Q );
@@ -2390,7 +2392,7 @@ cleanup:
  * Multiplication with Montgomery ladder in x/z coordinates,
  * for curves in Montgomery form
  */
-static int ecp_mul_mxz( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
+int ecp_mul_mxz( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
                         const mbedtls_mpi *m, const mbedtls_ecp_point *P,
                         int (*f_rng)(void *, unsigned char *, size_t),
                         void *p_rng )
@@ -2545,7 +2547,7 @@ int mbedtls_ecp_mul_restartable( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
 
     if( GET_WORD_LEN( grp->pbits ) <= PKE_OPERAND_MAX_WORD_LEN )
-        return( ecp_alt_b9x_backend_mul( grp, R, m, P ) );
+        return( ecp_alt_b9x_backend_mul( grp, R, m, P, f_rng, p_rng, rs_ctx ) );
 
     return( ecp_mul_restartable_internal( grp, R, m, P, f_rng, p_rng, rs_ctx ) );
 }

--- a/tlsr9/drivers/B95/pke.h
+++ b/tlsr9/drivers/B95/pke.h
@@ -32,7 +32,20 @@ extern "C" {
 #include "reg_include/pke_reg.h"
 //#include "pke_common.h"
 #include "eccp_curve.h"
+#include "utility.h"
 
+#define pke_clr_irq_status			pke_clear_interrupt
+#define pke_get_irq_status			pke_wait_till_done
+#define pke_opr_start				pke_start
+#define pke_mod_add					pke_modadd
+#define pke_mod_sub					pke_modsub
+#define pke_mod_mul					pke_modmul
+#define pke_mod_inv					pke_modinv
+#define div2n_u32					Big_Div2n
+#define sub_u32						pke_sub
+#define pke_eccp_point_mul			eccp_pointMul
+#define pke_eccp_point_add			eccp_pointAdd
+#define pke_eccp_point_verify		eccp_pointVerify
 
 //#define SUPPORT_SM2
 //#define SUPPORT_C25519


### PR DESCRIPTION
- Add crypto driver for B95.
- Replace the original AES encryption functionality with the SKE module.
- Due to B95's lack of hardware support for Curve25519, the software method `ecp_mul_mxz` is used instead.
- Updated B95 pke file.