### PR TITLE
drivers: crypto: added crypto driver for TL321X

### DIFF
--- a/tlsr9/crypto/mbedtls/internal/compatibility/ecp_alt.c
+++ b/tlsr9/crypto/mbedtls/internal/compatibility/ecp_alt.c
@@ -2548,6 +2548,10 @@ int mbedtls_ecp_mul_restartable( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
     ECP_VALIDATE_RET( m   != NULL );
     ECP_VALIDATE_RET( P   != NULL );
 
+#if CONFIG_SOC_RISCV_TELINK_TL321X
+    pke_dig_en();
+#endif
+
     if( f_rng == NULL )
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
 
@@ -2681,6 +2685,10 @@ int mbedtls_ecp_muladd_restartable(
     ECP_VALIDATE_RET( P   != NULL );
     ECP_VALIDATE_RET( n   != NULL );
     ECP_VALIDATE_RET( Q   != NULL );
+
+#if CONFIG_SOC_RISCV_TELINK_TL321X
+    pke_dig_en();
+#endif
 
     if( mbedtls_ecp_get_type( grp ) != MBEDTLS_ECP_TYPE_SHORT_WEIERSTRASS )
         return( MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE );
@@ -2897,6 +2905,10 @@ int mbedtls_ecp_check_pubkey( const mbedtls_ecp_group *grp,
 {
     ECP_VALIDATE_RET( grp != NULL );
     ECP_VALIDATE_RET( pt  != NULL );
+
+#if CONFIG_SOC_RISCV_TELINK_TL321X
+    pke_dig_en();
+#endif
 
     /* Must use affine coordinates */
     if( mbedtls_mpi_cmp_int( &pt->Z, 1 ) != 0 )

--- a/tlsr9/crypto/mbedtls/internal/ecp_alt_b9x_backend.c
+++ b/tlsr9/crypto/mbedtls/internal/ecp_alt_b9x_backend.c
@@ -72,6 +72,8 @@ extern int ecp_mul_mxz( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
  ****************************************************************/
 
 #if defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED)
+
+#if CONFIG_SOC_RISCV_TELINK_B91 || CONFIG_SOC_RISCV_TELINK_B92 || CONFIG_SOC_RISCV_TELINK_B95
 static eccp_curve_t secp256r1_curve_dat = {
 	.eccp_p_bitLen = 256,
 	.eccp_p = (unsigned int[]){
@@ -92,9 +94,35 @@ static eccp_curve_t secp256r1_curve_dat = {
 		0x769886bc, 0xb3ebbd55, 0xaa3a93e7, 0x5ac635d8
 	}
 };
+#elif CONFIG_SOC_RISCV_TELINK_TL321X
+static eccp_curve_t secp256r1_curve_dat = {
+	.eccp_p_bitLen = 256,
+	.eccp_n_bitLen = 256,
+	.eccp_p = (unsigned int[]){
+		0xffffffff, 0xffffffff, 0xffffffff, 0x00000000,
+		0x00000000, 0x00000000, 0x00000001, 0xffffffff
+	},
+	.eccp_p_h = (unsigned int[]){
+		0x00000003, 0x00000000, 0xffffffff, 0xfffffffb,
+		0xfffffffe, 0xffffffff, 0xfffffffd, 0x00000004
+	},
+	.eccp_p_n0 = (unsigned int[]){0x00000001},
+	.eccp_a = (unsigned int[]){
+		0xfffffffc, 0xffffffff, 0xffffffff, 0x00000000,
+		0x00000000, 0x00000000, 0x00000001, 0xffffffff
+	},
+	.eccp_b = (unsigned int[]){
+		0x27d2604b, 0x3bce3c3e, 0xcc53b0f6, 0x651d06b0,
+		0x769886bc, 0xb3ebbd55, 0xaa3a93e7, 0x5ac635d8
+	}
+};
+#endif
+
 #endif /* MBEDTLS_ECP_DP_SECP256R1_ENABLED */
 
 #if defined(MBEDTLS_ECP_DP_SECP256K1_ENABLED)
+
+#if CONFIG_SOC_RISCV_TELINK_B91 || CONFIG_SOC_RISCV_TELINK_B92 || CONFIG_SOC_RISCV_TELINK_B95
 static eccp_curve_t secp256k1_curve_dat = {
 	.eccp_p_bitLen = 256,
 	.eccp_p = (unsigned int[]){
@@ -115,9 +143,35 @@ static eccp_curve_t secp256k1_curve_dat = {
 		0x00000000, 0x00000000, 0x00000000, 0x00000000
 	}
 };
+#elif CONFIG_SOC_RISCV_TELINK_TL321X
+static eccp_curve_t secp256k1_curve_dat = {
+	.eccp_p_bitLen = 256,
+	.eccp_n_bitLen = 256,
+	.eccp_p = (unsigned int[]){
+		0xfffffc2f, 0xfffffffe, 0xffffffff, 0xffffffff,
+		0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff
+	},
+	.eccp_p_h = (unsigned int[]){
+		0x000e90a1, 0x000007a2, 0x00000001, 0x00000000,
+		0x00000000, 0x00000000, 0x00000000, 0x00000000
+	},
+	.eccp_p_n0 = (unsigned int[]){0xd2253531},
+	.eccp_a = (unsigned int[]){
+		0x00000000, 0x00000000, 0x00000000, 0x00000000,
+		0x00000000, 0x00000000, 0x00000000, 0x00000000
+	},
+	.eccp_b = (unsigned int[]){
+		0x00000007, 0x00000000, 0x00000000, 0x00000000,
+		0x00000000, 0x00000000, 0x00000000, 0x00000000
+	}
+};
+#endif
+
 #endif /* MBEDTLS_ECP_DP_SECP256K1_ENABLED */
 
 #if defined(MBEDTLS_ECP_DP_BP256R1_ENABLED)
+
+#if CONFIG_SOC_RISCV_TELINK_B91 || CONFIG_SOC_RISCV_TELINK_B92 || CONFIG_SOC_RISCV_TELINK_B95
 static eccp_curve_t BP256r1_curve_dat = {
 	.eccp_p_bitLen = 256,
 	.eccp_p = (unsigned int[]){
@@ -138,9 +192,35 @@ static eccp_curve_t BP256r1_curve_dat = {
 		0xbbd77cbf, 0xf330b5d9, 0xe94a4b44, 0x26dc5c6c
 	}
 };
+#elif CONFIG_SOC_RISCV_TELINK_TL321X
+static eccp_curve_t BP256r1_curve_dat = {
+	.eccp_p_bitLen = 256,
+	.eccp_n_bitLen = 256,
+	.eccp_p = (unsigned int[]){
+		0x1f6e5377, 0x2013481d, 0xd5262028, 0x6e3bf623,
+		0x9d838d72, 0x3e660a90, 0xa1eea9bc, 0xa9fb57db
+	},
+	.eccp_p_h = (unsigned int[]){
+		0xa6465b6c, 0x8cfedf7b, 0x614d4f4d, 0x5cce4c26,
+		0x6b1ac807, 0xa1ecdacd, 0xe5957fa8, 0x4717aa21
+	},
+	.eccp_p_n0 = (unsigned int[]){0xcefd89b9},
+	.eccp_a = (unsigned int[]){
+		0xf330b5d9, 0xe94a4b44, 0x26dc5c6c, 0xfb8055c1,
+		0x417affe7, 0xeef67530, 0xfc2c3057, 0x7d5a0975
+	},
+	.eccp_b = (unsigned int[]){
+		0xff8c07b6, 0x6bccdc18, 0x5cf7e1ce, 0x95841629,
+		0xbbd77cbf, 0xf330b5d9, 0xe94a4b44, 0x26dc5c6c
+	}
+};
+#endif
+
 #endif /* MBEDTLS_ECP_DP_BP256R1_ENABLED */
 
 #if defined(MBEDTLS_ECP_DP_SECP224R1_ENABLED)
+
+#if CONFIG_SOC_RISCV_TELINK_B91 || CONFIG_SOC_RISCV_TELINK_B92 || CONFIG_SOC_RISCV_TELINK_B95
 static eccp_curve_t secp224r1_curve_dat = {
 	.eccp_p_bitLen = 224,
 	.eccp_p = (unsigned int[]){
@@ -161,9 +241,35 @@ static eccp_curve_t secp224r1_curve_dat = {
 		0xf5413256, 0x0c04b3ab, 0xb4050a85
 	}
 };
+#elif CONFIG_SOC_RISCV_TELINK_TL321X
+static eccp_curve_t secp224r1_curve_dat = {
+	.eccp_p_bitLen = 224,
+	.eccp_n_bitLen = 224,
+	.eccp_p = (unsigned int[]){
+		0x00000001, 0x00000000, 0x00000000, 0xffffffff,
+		0xffffffff, 0xffffffff, 0xffffffff
+	},
+	.eccp_p_h = (unsigned int[]){
+		0x00000001, 0x00000000, 0x00000000, 0xfffffffe,
+		0xffffffff, 0xffffffff, 0x00000000
+	},
+	.eccp_p_n0 = (unsigned int[]){0xffffffff},
+	.eccp_a = (unsigned int[]){
+		0xfffffffe, 0xffffffff, 0xffffffff, 0xfffffffe,
+		0xffffffff, 0xffffffff, 0xffffffff
+	},
+	.eccp_b = (unsigned int[]){
+		0x2355ffb4, 0x270b3943, 0xd7bfd8ba, 0x5044b0b7,
+		0xf5413256, 0x0c04b3ab, 0xb4050a85
+	}
+};
+#endif
+
 #endif /* MBEDTLS_ECP_DP_SECP224R1_ENABLED */
 
 #if defined(MBEDTLS_ECP_DP_SECP224K1_ENABLED)
+
+#if CONFIG_SOC_RISCV_TELINK_B91 || CONFIG_SOC_RISCV_TELINK_B92 || CONFIG_SOC_RISCV_TELINK_B95
 static eccp_curve_t secp224k1_curve_dat = {
 	.eccp_p_bitLen = 224,
 	.eccp_p = (unsigned int[]){
@@ -184,9 +290,35 @@ static eccp_curve_t secp224k1_curve_dat = {
 		0x00000000, 0x00000000, 0x00000000
 	}
 };
+#elif CONFIG_SOC_RISCV_TELINK_TL321X
+static eccp_curve_t secp224k1_curve_dat = {
+	.eccp_p_bitLen = 224,
+	.eccp_n_bitLen = 224,
+	.eccp_p = (unsigned int[]){
+		0xffffe56d, 0xfffffffe, 0xffffffff, 0xffffffff,
+		0xffffffff, 0xffffffff, 0xffffffff
+	},
+	.eccp_p_h = (unsigned int[]){
+		0x02c23069, 0x00003526, 0x00000001, 0x00000000,
+		0x00000000, 0x00000000, 0x00000000
+	},
+	.eccp_p_n0 = (unsigned int[]){0x198d139b},
+	.eccp_a = (unsigned int[]){
+		0x00000000, 0x00000000, 0x00000000, 0x00000000,
+		0x00000000, 0x00000000, 0x00000000
+	},
+	.eccp_b = (unsigned int[]){
+		0x00000005, 0x00000000, 0x00000000, 0x00000000,
+		0x00000000, 0x00000000, 0x00000000
+	}
+};
+#endif
+
 #endif /* MBEDTLS_ECP_DP_SECP224K1_ENABLED */
 
 #if defined(MBEDTLS_ECP_DP_SECP192R1_ENABLED)
+
+#if CONFIG_SOC_RISCV_TELINK_B91 || CONFIG_SOC_RISCV_TELINK_B92 || CONFIG_SOC_RISCV_TELINK_B95
 static eccp_curve_t secp192r1_curve_dat = {
 	.eccp_p_bitLen = 192,
 	.eccp_p = (unsigned int[]){
@@ -207,9 +339,35 @@ static eccp_curve_t secp192r1_curve_dat = {
 		0xe59c80e7, 0x64210519
 	}
 };
+#elif CONFIG_SOC_RISCV_TELINK_TL321X
+static eccp_curve_t secp192r1_curve_dat = {
+	.eccp_p_bitLen = 192,
+	.eccp_n_bitLen = 192,
+	.eccp_p = (unsigned int[]){
+		0xffffffff, 0xffffffff, 0xfffffffe, 0xffffffff,
+		0xffffffff, 0xffffffff
+	},
+	.eccp_p_h = (unsigned int[]){
+		0x00000001, 0x00000000, 0x00000002, 0x00000000,
+		0x00000001, 0x00000000
+	},
+	.eccp_p_n0 = (unsigned int[]){0x00000001},
+	.eccp_a = (unsigned int[]){
+		0xfffffffc, 0xffffffff, 0xfffffffe, 0xffffffff,
+		0xffffffff, 0xffffffff
+	},
+	.eccp_b = (unsigned int[]){
+		0xc146b9b1, 0xfeb8deec, 0x72243049, 0x0fa7e9ab,
+		0xe59c80e7, 0x64210519
+	}
+};
+#endif
+
 #endif /* MBEDTLS_ECP_DP_SECP192R1_ENABLED */
 
 #if defined(MBEDTLS_ECP_DP_SECP192K1_ENABLED)
+
+#if CONFIG_SOC_RISCV_TELINK_B91 || CONFIG_SOC_RISCV_TELINK_B92 || CONFIG_SOC_RISCV_TELINK_B95
 static eccp_curve_t secp192k1_curve_dat = {
 	.eccp_p_bitLen = 192,
 	.eccp_p = (unsigned int[]){
@@ -230,6 +388,30 @@ static eccp_curve_t secp192k1_curve_dat = {
 		0x00000000, 0x00000000
 	}
 };
+#elif CONFIG_SOC_RISCV_TELINK_TL321X
+static eccp_curve_t secp192k1_curve_dat = {
+	.eccp_p_bitLen = 192,
+	.eccp_n_bitLen = 192,
+	.eccp_p = (unsigned int[]){
+		0xffffee37, 0xfffffffe, 0xffffffff, 0xffffffff,
+		0xffffffff, 0xffffffff
+	},
+	.eccp_p_h = (unsigned int[]){
+		0x013c4fd1, 0x00002392, 0x00000001, 0x00000000,
+		0x00000000, 0x00000000
+	},
+	.eccp_p_n0 = (unsigned int[]){0x7446d879},
+	.eccp_a = (unsigned int[]){
+		0x00000000, 0x00000000, 0x00000000, 0x00000000,
+		0x00000000, 0x00000000
+	},
+	.eccp_b = (unsigned int[]){
+		0x00000003, 0x00000000, 0x00000000, 0x00000000,
+		0x00000000, 0x00000000
+	}
+};
+#endif
+
 #endif /* MBEDTLS_ECP_DP_SECP192K1_ENABLED */
 
 #if defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED)
@@ -251,7 +433,7 @@ static mont_curve_t x25519 = {
 		0x00000000, 0x00000000, 0x00000000, 0x00000000
 	}
 };
-#elif CONFIG_SOC_RISCV_TELINK_B92 || CONFIG_SOC_RISCV_TELINK_B95 || CONFIG_SOC_RISCV_TELINK_TL321X
+#elif CONFIG_SOC_RISCV_TELINK_B92 || CONFIG_SOC_RISCV_TELINK_B95
 static mont_curve_t x25519 = {
 	.p_bitLen = 255,
 	.p = (unsigned int[]){
@@ -263,6 +445,24 @@ static mont_curve_t x25519 = {
 		0x00000000, 0x00000000, 0x00000000, 0x00000000
 	},
 	.p_n1 = (unsigned int[]){0x286bca1b},
+	.a24 = (unsigned int[]){
+		0x0001db41, 0x00000000, 0x00000000, 0x00000000,
+		0x00000000, 0x00000000, 0x00000000, 0x00000000
+	}
+};
+#elif CONFIG_SOC_RISCV_TELINK_TL321X
+static mont_curve_t x25519 = {
+	.p_bitLen = 255,
+	.n_bitLen = 253,
+	.p = (unsigned int[]){
+		0xffffffed, 0xffffffff, 0xffffffff, 0xffffffff,
+		0xffffffff, 0xffffffff, 0xffffffff, 0x7fffffff
+	},
+	.p_h = (unsigned int[]){
+		0x000005a4, 0x00000000, 0x00000000, 0x00000000,
+		0x00000000, 0x00000000, 0x00000000, 0x00000000
+	},
+	.p_n0 = (unsigned int[]){0x286bca1b},
 	.a24 = (unsigned int[]){
 		0x0001db41, 0x00000000, 0x00000000, 0x00000000,
 		0x00000000, 0x00000000, 0x00000000, 0x00000000

--- a/tlsr9/drivers/TL321X/lib/include/pke/pke.h
+++ b/tlsr9/drivers/TL321X/lib/include/pke/pke.h
@@ -32,7 +32,10 @@ extern "C" {
 
 #include "pke_common.h"
 #include "lib/include/crypto_common/eccp_curve.h"
+#include "lib/include/crypto_common/utility.h"
+#include "pke_portable.h"
 
+#define SUPPORT_C25519
 
 #ifdef SUPPORT_SM2
 extern eccp_curve_t sm2_curve[1];
@@ -46,6 +49,23 @@ extern eccp_curve_t sm9_curve[1];
 extern edward_curve_t ed25519[1];
 #endif
 
+#define big_integer_compare			uint32_BigNumCmp
+
+#define pke_clr_irq_status			pke_clear_interrupt
+#define pke_get_irq_status			pke_wait_till_done
+#define pke_opr_start				pke_start
+#define pke_mod_add					pke_modadd
+#define pke_mod_sub					pke_modsub
+#define pke_mod_mul					pke_modmul
+#define pke_mod_inv					pke_modinv
+#define div2n_u32					Big_Div2n
+#define sub_u32						pke_sub
+#define pke_eccp_point_mul			eccp_pointMul
+#define pke_eccp_point_add			eccp_pointAdd
+#define pke_eccp_point_verify		eccp_pointVerify
+#define pke_x25519_point_mul		x25519_pointMul
+#define pke_ed25519_point_mul		ed25519_pointMul
+#define pke_ed25519_point_add		ed25519_pointAdd
 
 /***************** PKE register *******************/
 #define rPKE_CTRL           (*((volatile unsigned int *)(PKE_BASE_ADDR)))


### PR DESCRIPTION
- add crypto driver for TL321X.
- update tl321x pke.h file.
- update the struct eccp_curve_t and mont_curve_t.