### PR TITLE
telink: b92: use malloc in acl and hci .

### DIFF
--- a/tlsr9/CMakeLists.txt
+++ b/tlsr9/CMakeLists.txt
@@ -114,19 +114,28 @@ zephyr_library_sources_ifdef(CONFIG_PM common/sleep.c)
 #BLE flash reference sources
 if (CONFIG_IEEE802154_TELINK_B9X OR CONFIG_IEEE802154_TELINK_TLX)
 
-zephyr_include_directories(
+zephyr_include_directories_ifdef(CONFIG_IEEE802154_TELINK_B9X
 	ble
-	ble/vendor/controller
+	ble/vendor/controller/b9x
+)
+
+zephyr_include_directories_ifdef(CONFIG_IEEE802154_TELINK_TLX
+	ble
+	ble/vendor/controller/tlx
 )
 
 endif()
 
 # BLE stack reference sources
-if (CONFIG_BT_B9X OR CONFIG_BT_TLX OR CONFIG_IEEE802154)
+if (CONFIG_BT_B9X OR CONFIG_BT_TLX)
 
-zephyr_include_directories(
+zephyr_include_directories_ifdef(CONFIG_BT_B9X
 	ble
 	ble/vendor/controller/b9x
+)
+
+zephyr_include_directories_ifdef(CONFIG_BT_TLX
+	ble
 	ble/vendor/controller/tlx
 )
 

--- a/tlsr9/ble/vendor/controller/tlx/tlx_bt.c
+++ b/tlsr9/ble/vendor/controller/tlx/tlx_bt.c
@@ -29,7 +29,8 @@
 #include "tlx_bt_init.h"
 #include "compiler.h"
 #include "plic.h"
-
+#include <stdlib.h>
+#include "tlx_bt_buffer.h"
 #if CONFIG_SOC_RISCV_TELINK_TL321X
 #include "stack/ble/TL321X/controller/ble_controller.h"
 #include "stack/ble/TL321X/controller/os_sup.h"
@@ -216,6 +217,19 @@ CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION)
 	/* Init RF driver */
 	rf_drv_ble_init();
 
+#ifdef CONFIG_BT_CENTRAL
+	app_acl_mstTxfifo = (u8 *)calloc(ACL_MASTER_TX_FIFO_SIZE * ACL_MASTER_TX_FIFO_NUM * CONFIG_B9X_BLE_CTRL_MASTER_MAX_NUM,1);
+#endif /* CONFIG_BT_CENTRAL */
+
+#ifdef CONFIG_BT_PERIPHERAL
+	app_acl_slvTxfifo = (u8 *)calloc(ACL_SLAVE_TX_FIFO_SIZE * ACL_SLAVE_TX_FIFO_NUM * CONFIG_B9X_BLE_CTRL_SLAVE_MAX_NUM,1);
+#endif /* CONFIG_BT_PERIPHERAL */
+	
+	app_acl_rxfifo = (u8 *)calloc(ACL_RX_FIFO_SIZE * ACL_RX_FIFO_NUM,1);
+	app_hci_rxfifo = (u8 *)calloc(HCI_RX_FIFO_SIZE * HCI_RX_FIFO_NUM,1);
+	app_hci_txfifo = (u8 *)calloc(HCI_TX_FIFO_SIZE * HCI_TX_FIFO_NUM,1);
+	app_hci_rxAclfifo = (u8 *)calloc(HCI_RX_ACL_FIFO_SIZE * HCI_RX_ACL_FIFO_NUM,1);
+
 	/* Init BLE Controller stack */
 	status = b9x_bt_blc_init(b9x_bt_hci_rx_handler, b9x_bt_hci_tx_handler);
 	if (status != INIT_OK) {
@@ -275,6 +289,18 @@ void b9x_bt_controller_deinit()
 	rf_reset_dma();
 	rf_baseband_reset();
 #endif
+
+#ifdef CONFIG_BT_CENTRAL
+	free(app_acl_mstTxfifo);
+#endif /* CONFIG_BT_CENTRAL */
+#ifdef CONFIG_BT_PERIPHERAL
+	free(app_acl_slvTxfifo);
+#endif /* CONFIG_BT_PERIPHERAL */
+	free(app_acl_rxfifo);
+	free(app_hci_rxfifo);
+	free(app_hci_txfifo);
+	free(app_hci_rxAclfifo);
+
 
 #if CONFIG_PM && (CONFIG_SOC_SERIES_RISCV_TELINK_B9X_RETENTION || \
 CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION)

--- a/tlsr9/ble/vendor/controller/tlx/tlx_bt_buffer.c
+++ b/tlsr9/ble/vendor/controller/tlx/tlx_bt_buffer.c
@@ -19,16 +19,14 @@
 #include "tlx_bt_buffer.h"
 
 /******* ACL connection LinkLayer TX & RX data FIFO allocation, Begin ********/
-_attribute_data_ u8 app_acl_rxfifo[ACL_RX_FIFO_SIZE * ACL_RX_FIFO_NUM] = {0};
+_attribute_data_ u8* app_acl_rxfifo;
 #ifdef CONFIG_BT_CENTRAL
-_attribute_data_ u8 app_acl_mstTxfifo[ACL_MASTER_TX_FIFO_SIZE * ACL_MASTER_TX_FIFO_NUM *
-		     CONFIG_B9X_BLE_CTRL_MASTER_MAX_NUM] = {0};
+_attribute_data_ u8* app_acl_mstTxfifo;
 #endif /* CONFIG_BT_CENTRAL */
 #ifdef CONFIG_BT_PERIPHERAL
-_attribute_data_ u8 app_acl_slvTxfifo[ACL_SLAVE_TX_FIFO_SIZE * ACL_SLAVE_TX_FIFO_NUM *
-		     CONFIG_B9X_BLE_CTRL_SLAVE_MAX_NUM] = {0};
+_attribute_data_ u8* app_acl_slvTxfifo;
 #endif /* CONFIG_BT_PERIPHERAL */
 /******** HCI TX & RX data FIFO allocation, Begin  ***************************/
-_attribute_data_ u8 app_hci_rxfifo[HCI_RX_FIFO_SIZE * HCI_RX_FIFO_NUM] = {0};
-_attribute_data_ u8 app_hci_txfifo[HCI_TX_FIFO_SIZE * HCI_TX_FIFO_NUM] = {0};
-_attribute_data_ u8 app_hci_rxAclfifo[HCI_RX_ACL_FIFO_SIZE * HCI_RX_ACL_FIFO_NUM] = {0};
+_attribute_data_ u8* app_hci_rxfifo;
+_attribute_data_ u8* app_hci_txfifo;
+_attribute_data_ u8* app_hci_rxAclfifo;

--- a/tlsr9/ble/vendor/controller/tlx/tlx_bt_buffer.h
+++ b/tlsr9/ble/vendor/controller/tlx/tlx_bt_buffer.h
@@ -120,12 +120,11 @@
 */
 #define ACL_MASTER_TX_FIFO_NUM CAL_LL_ACL_BUF_NUM(CONFIG_BT_BUF_ACL_TX_COUNT)
 
-extern u8 app_acl_rxfifo[];
-extern u8 app_acl_mstTxfifo[];
-extern u8 app_acl_slvTxfifo[];
-
-extern u8 app_hci_rxfifo[];
-extern u8 app_hci_txfifo[];
-extern u8 app_hci_rxAclfifo[];
+extern _attribute_data_ u8* app_acl_rxfifo;
+extern _attribute_data_ u8* app_acl_mstTxfifo;
+extern _attribute_data_ u8* app_acl_slvTxfifo;
+extern _attribute_data_ u8* app_hci_rxfifo;
+extern _attribute_data_ u8* app_hci_txfifo;
+extern _attribute_data_ u8* app_hci_rxAclfifo;
 
 #endif /* TLX_BT_BUFFER_H_ */

--- a/tlsr9/ble/vendor/controller/tlx/tlx_bt_init.c
+++ b/tlsr9/ble/vendor/controller/tlx/tlx_bt_init.c
@@ -88,8 +88,6 @@ int b9x_bt_blc_init(void *prx, void *ptx)
 
 	blc_ll_initLegacyAdvertising_module(); // adv module: 		 mandatory for BLE slave,
 
-	blc_ll_initLegacyScanning_module(); // scan module: 		 mandatory for BLE master
-
 	blc_ll_initInitiating_module(); // initiate module: 	 mandatory for BLE master
 
 	blc_ll_initAclConnection_module();
@@ -150,7 +148,6 @@ int b9x_bt_blc_init(void *prx, void *ptx)
 
 #if CONFIG_SOC_RISCV_TELINK_TL321X
 	blc_ll_configLegacyAdvEnableStrategy(LEG_ADV_EN_STRATEGY_3);
-	blc_ll_configScanEnableStrategy(SCAN_STRATEGY_1);
 #endif
 
 	blc_ll_setMaxConnectionNumber(CONFIG_B9X_BLE_CTRL_MASTER_MAX_NUM,


### PR DESCRIPTION
- adjust cmakelist.
- save ram for acl and hci in tlx soc.