### PR TITLE
hal: telink: driver: usb: fix b92 endpoint switch

### DIFF
--- a/tlsr9/drivers/B92/usbhw.h
+++ b/tlsr9/drivers/B92/usbhw.h
@@ -281,7 +281,7 @@ static inline void usbhw_clr_irq_status(usb_irq_status_e status)
  */
 static inline void  usbhw_set_eps_en(usb_ep_en_e ep)
 {
-	reg_usb_edp_en= ep;
+	reg_usb_edp_en |= ep;
 }
 
 /**


### PR DESCRIPTION
Fix endpoint switch for b92.
Similar to commit 0b0d1fdadc15f44227b143b7acef25b0fc9f70e4 in our existing Pull Request https://github.com/telink-semi/hal_telink/pull/59.