### PR TITLE
telink: crypto: mbedtls: Update MbedTLS testing process for TL721X.

### DIFF
--- a/tlsr9/crypto/mbedtls/ecp_tlx_backend.c
+++ b/tlsr9/crypto/mbedtls/ecp_tlx_backend.c
@@ -34,24 +34,42 @@ LOG_MODULE_REGISTER(ecc_tlx, CONFIG_MBEDTLS_LOG_LEVEL);
  * HW unit curve data constants definition
  ****************************************************************/
 
+#if CONFIG_SOC_RISCV_TELINK_TL321X
+#define ECCP_P_BITLEN       eccp_p_bitLen
+#define ECCP_N_BITLEN       eccp_n_bitLen
+#define ECCP_P              eccp_p
+#define ECCP_P_H            eccp_p_h
+#define ECCP_P_N            eccp_p_n0
+#define ECCP_A              eccp_a
+#define ECCP_B              eccp_b
+#elif CONFIG_SOC_RISCV_TELINK_TL721X
+#define ECCP_P_BITLEN       eccp_p_bitLen
+#define ECCP_N_BITLEN       eccp_n_bitLen
+#define ECCP_P              eccp_p
+#define ECCP_P_H            eccp_p_h
+#define ECCP_P_N            eccp_p_n1
+#define ECCP_A              eccp_a
+#define ECCP_B              eccp_b
+#endif
+
 #if defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED)
 static eccp_curve_t secp256r1_curve_dat = {
-	.eccp_p_bitLen = 256,
-	.eccp_n_bitLen = 256,
-	.eccp_p = (unsigned int[]){
+	.ECCP_P_BITLEN = 256,
+	.ECCP_N_BITLEN = 256,
+	.ECCP_P = (unsigned int[]){
 		0xffffffff, 0xffffffff, 0xffffffff, 0x00000000,
 		0x00000000, 0x00000000, 0x00000001, 0xffffffff
 	},
-	.eccp_p_h = (unsigned int[]){
+	.ECCP_P_H = (unsigned int[]){
 		0x00000003, 0x00000000, 0xffffffff, 0xfffffffb,
 		0xfffffffe, 0xffffffff, 0xfffffffd, 0x00000004
 	},
-	.eccp_p_n0 = (unsigned int[]){0x00000001},
-	.eccp_a = (unsigned int[]){
+	.ECCP_P_N = (unsigned int[]){0x00000001},
+	.ECCP_A = (unsigned int[]){
 		0xfffffffc, 0xffffffff, 0xffffffff, 0x00000000,
 		0x00000000, 0x00000000, 0x00000001, 0xffffffff
 	},
-	.eccp_b = (unsigned int[]){
+	.ECCP_B = (unsigned int[]){
 		0x27d2604b, 0x3bce3c3e, 0xcc53b0f6, 0x651d06b0,
 		0x769886bc, 0xb3ebbd55, 0xaa3a93e7, 0x5ac635d8
 	}
@@ -60,22 +78,22 @@ static eccp_curve_t secp256r1_curve_dat = {
 
 #if defined(MBEDTLS_ECP_DP_SECP256K1_ENABLED)
 static eccp_curve_t secp256k1_curve_dat = {
-	.eccp_p_bitLen = 256,
-	.eccp_n_bitLen = 256,
-	.eccp_p = (unsigned int[]){
+	.ECCP_P_BITLEN = 256,
+	.ECCP_N_BITLEN = 256,
+	.ECCP_P = (unsigned int[]){
 		0xfffffc2f, 0xfffffffe, 0xffffffff, 0xffffffff,
 		0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff
 	},
-	.eccp_p_h = (unsigned int[]){
+	.ECCP_P_H = (unsigned int[]){
 		0x000e90a1, 0x000007a2, 0x00000001, 0x00000000,
 		0x00000000, 0x00000000, 0x00000000, 0x00000000
 	},
-	.eccp_p_n0 = (unsigned int[]){0xd2253531},
-	.eccp_a = (unsigned int[]){
+	.ECCP_P_N = (unsigned int[]){0xd2253531},
+	.ECCP_A = (unsigned int[]){
 		0x00000000, 0x00000000, 0x00000000, 0x00000000,
 		0x00000000, 0x00000000, 0x00000000, 0x00000000
 	},
-	.eccp_b = (unsigned int[]){
+	.ECCP_B = (unsigned int[]){
 		0x00000007, 0x00000000, 0x00000000, 0x00000000,
 		0x00000000, 0x00000000, 0x00000000, 0x00000000
 	}
@@ -84,22 +102,22 @@ static eccp_curve_t secp256k1_curve_dat = {
 
 #if defined(MBEDTLS_ECP_DP_BP256R1_ENABLED)
 static eccp_curve_t BP256r1_curve_dat = {
-	.eccp_p_bitLen = 256,
-	.eccp_n_bitLen = 256,
-	.eccp_p = (unsigned int[]){
+	.ECCP_P_BITLEN = 256,
+	.ECCP_N_BITLEN = 256,
+	.ECCP_P = (unsigned int[]){
 		0x1f6e5377, 0x2013481d, 0xd5262028, 0x6e3bf623,
 		0x9d838d72, 0x3e660a90, 0xa1eea9bc, 0xa9fb57db
 	},
-	.eccp_p_h = (unsigned int[]){
+	.ECCP_P_H = (unsigned int[]){
 		0xa6465b6c, 0x8cfedf7b, 0x614d4f4d, 0x5cce4c26,
 		0x6b1ac807, 0xa1ecdacd, 0xe5957fa8, 0x4717aa21
 	},
-	.eccp_p_n0 = (unsigned int[]){0xcefd89b9},
-	.eccp_a = (unsigned int[]){
+	.ECCP_P_N = (unsigned int[]){0xcefd89b9},
+	.ECCP_A = (unsigned int[]){
 		0xf330b5d9, 0xe94a4b44, 0x26dc5c6c, 0xfb8055c1,
 		0x417affe7, 0xeef67530, 0xfc2c3057, 0x7d5a0975
 	},
-	.eccp_b = (unsigned int[]){
+	.ECCP_B = (unsigned int[]){
 		0xff8c07b6, 0x6bccdc18, 0x5cf7e1ce, 0x95841629,
 		0xbbd77cbf, 0xf330b5d9, 0xe94a4b44, 0x26dc5c6c
 	}
@@ -108,22 +126,22 @@ static eccp_curve_t BP256r1_curve_dat = {
 
 #if defined(MBEDTLS_ECP_DP_SECP224R1_ENABLED)
 static eccp_curve_t secp224r1_curve_dat = {
-	.eccp_p_bitLen = 224,
-	.eccp_n_bitLen = 224,
-	.eccp_p = (unsigned int[]){
+	.ECCP_P_BITLEN = 224,
+	.ECCP_N_BITLEN = 224,
+	.ECCP_P = (unsigned int[]){
 		0x00000001, 0x00000000, 0x00000000, 0xffffffff,
 		0xffffffff, 0xffffffff, 0xffffffff
 	},
-	.eccp_p_h = (unsigned int[]){
+	.ECCP_P_H = (unsigned int[]){
 		0x00000001, 0x00000000, 0x00000000, 0xfffffffe,
 		0xffffffff, 0xffffffff, 0x00000000
 	},
-	.eccp_p_n0 = (unsigned int[]){0xffffffff},
-	.eccp_a = (unsigned int[]){
+	.ECCP_P_N = (unsigned int[]){0xffffffff},
+	.ECCP_A = (unsigned int[]){
 		0xfffffffe, 0xffffffff, 0xffffffff, 0xfffffffe,
 		0xffffffff, 0xffffffff, 0xffffffff
 	},
-	.eccp_b = (unsigned int[]){
+	.ECCP_B = (unsigned int[]){
 		0x2355ffb4, 0x270b3943, 0xd7bfd8ba, 0x5044b0b7,
 		0xf5413256, 0x0c04b3ab, 0xb4050a85
 	}
@@ -132,22 +150,22 @@ static eccp_curve_t secp224r1_curve_dat = {
 
 #if defined(MBEDTLS_ECP_DP_SECP224K1_ENABLED)
 static eccp_curve_t secp224k1_curve_dat = {
-	.eccp_p_bitLen = 224,
-	.eccp_n_bitLen = 224,
-	.eccp_p = (unsigned int[]){
+	.ECCP_P_BITLEN = 224,
+	.ECCP_N_BITLEN = 224,
+	.ECCP_P = (unsigned int[]){
 		0xffffe56d, 0xfffffffe, 0xffffffff, 0xffffffff,
 		0xffffffff, 0xffffffff, 0xffffffff
 	},
-	.eccp_p_h = (unsigned int[]){
+	.ECCP_P_H = (unsigned int[]){
 		0x02c23069, 0x00003526, 0x00000001, 0x00000000,
 		0x00000000, 0x00000000, 0x00000000
 	},
-	.eccp_p_n0 = (unsigned int[]){0x198d139b},
-	.eccp_a = (unsigned int[]){
+	.ECCP_P_N = (unsigned int[]){0x198d139b},
+	.ECCP_A = (unsigned int[]){
 		0x00000000, 0x00000000, 0x00000000, 0x00000000,
 		0x00000000, 0x00000000, 0x00000000
 	},
-	.eccp_b = (unsigned int[]){
+	.ECCP_B = (unsigned int[]){
 		0x00000005, 0x00000000, 0x00000000, 0x00000000,
 		0x00000000, 0x00000000, 0x00000000
 	}
@@ -156,22 +174,22 @@ static eccp_curve_t secp224k1_curve_dat = {
 
 #if defined(MBEDTLS_ECP_DP_SECP192R1_ENABLED)
 static eccp_curve_t secp192r1_curve_dat = {
-	.eccp_p_bitLen = 192,
-	.eccp_n_bitLen = 192,
-	.eccp_p = (unsigned int[]){
+	.ECCP_P_BITLEN = 192,
+	.ECCP_N_BITLEN = 192,
+	.ECCP_P = (unsigned int[]){
 		0xffffffff, 0xffffffff, 0xfffffffe, 0xffffffff,
 		0xffffffff, 0xffffffff
 	},
-	.eccp_p_h = (unsigned int[]){
+	.ECCP_P_H = (unsigned int[]){
 		0x00000001, 0x00000000, 0x00000002, 0x00000000,
 		0x00000001, 0x00000000
 	},
-	.eccp_p_n0 = (unsigned int[]){0x00000001},
-	.eccp_a = (unsigned int[]){
+	.ECCP_P_N = (unsigned int[]){0x00000001},
+	.ECCP_A = (unsigned int[]){
 		0xfffffffc, 0xffffffff, 0xfffffffe, 0xffffffff,
 		0xffffffff, 0xffffffff
 	},
-	.eccp_b = (unsigned int[]){
+	.ECCP_B = (unsigned int[]){
 		0xc146b9b1, 0xfeb8deec, 0x72243049, 0x0fa7e9ab,
 		0xe59c80e7, 0x64210519
 	}
@@ -180,22 +198,22 @@ static eccp_curve_t secp192r1_curve_dat = {
 
 #if defined(MBEDTLS_ECP_DP_SECP192K1_ENABLED)
 static eccp_curve_t secp192k1_curve_dat = {
-	.eccp_p_bitLen = 192,
-	.eccp_n_bitLen = 192,
-	.eccp_p = (unsigned int[]){
+	.ECCP_P_BITLEN = 192,
+	.ECCP_N_BITLEN = 192,
+	.ECCP_P = (unsigned int[]){
 		0xffffee37, 0xfffffffe, 0xffffffff, 0xffffffff,
 		0xffffffff, 0xffffffff
 	},
-	.eccp_p_h = (unsigned int[]){
+	.ECCP_P_H = (unsigned int[]){
 		0x013c4fd1, 0x00002392, 0x00000001, 0x00000000,
 		0x00000000, 0x00000000
 	},
-	.eccp_p_n0 = (unsigned int[]){0x7446d879},
-	.eccp_a = (unsigned int[]){
+	.ECCP_P_N = (unsigned int[]){0x7446d879},
+	.ECCP_A = (unsigned int[]){
 		0x00000000, 0x00000000, 0x00000000, 0x00000000,
 		0x00000000, 0x00000000
 	},
-	.eccp_b = (unsigned int[]){
+	.ECCP_B = (unsigned int[]){
 		0x00000003, 0x00000000, 0x00000000, 0x00000000,
 		0x00000000, 0x00000000
 	}
@@ -203,6 +221,22 @@ static eccp_curve_t secp192k1_curve_dat = {
 #endif /* MBEDTLS_ECP_DP_SECP192K1_ENABLED */
 
 #if defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED)
+
+#if CONFIG_SOC_RISCV_TELINK_TL721X
+/* dummy function to compile */
+inline static uint8_t pke_x25519_point_mul(mont_curve_t *curve,
+	uint32_t *k, uint32_t *Pu, uint32_t *Qu)
+{
+	(void) curve;
+	(void) k;
+	(void) Pu;
+	(void) Qu;
+
+	return PKE_INVALID_INPUT;
+}
+#endif
+
+#if CONFIG_SOC_RISCV_TELINK_TL321X
 static mont_curve_t x25519 = {
 	.p_bitLen = 255,
 	.n_bitLen = 253,
@@ -220,6 +254,8 @@ static mont_curve_t x25519 = {
 		0x00000000, 0x00000000, 0x00000000, 0x00000000
 	}
 };
+#endif	/*CONFIG_SOC_RISCV_TELINK_TL321X*/
+
 #endif /* MBEDTLS_ECP_DP_CURVE25519_ENABLED */
 
 /****************************************************************
@@ -261,7 +297,9 @@ static const struct {
 	mont_curve_t *curve_dat;
 } mont_curve_linking[] = {
 #if defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED)
+#if CONFIG_SOC_RISCV_TELINK_TL321X
 	{.group = MBEDTLS_ECP_DP_CURVE25519, .curve_dat = &x25519}
+#endif /*CONFIG_SOC_RISCV_TELINK_TL321X*/
 #endif /* MBEDTLS_ECP_DP_CURVE25519_ENABLED */
 };
 #endif /* MBEDTLS_ECP_MONTGOMERY_ENABLED */

--- a/tlsr9/drivers/TL721X/lib/include/pke/pke.h
+++ b/tlsr9/drivers/TL721X/lib/include/pke/pke.h
@@ -29,9 +29,22 @@ extern "C" {
 
 
 //#define SUPPORT_SM2
-#define SUPPORT_C25519
+// #define SUPPORT_C25519
 
+#define big_integer_compare			uint32_BigNumCmp
 
+#define pke_clr_irq_status			pke_clear_interrupt
+#define pke_get_irq_status			pke_wait_till_done
+#define pke_opr_start				pke_start
+#define pke_mod_add					pke_modadd
+#define pke_mod_sub					pke_modsub
+#define pke_mod_mul					pke_modmul
+#define pke_mod_inv					pke_modinv
+#define div2n_u32					Big_Div2n
+#define sub_u32						pke_sub
+#define pke_eccp_point_mul			eccp_pointMul
+#define pke_eccp_point_add			eccp_pointAdd
+#define pke_eccp_point_verify		eccp_pointVerify
 
 
 /***************** PKE register *******************/


### PR DESCRIPTION
- add pke_x25519_point_mul dummy func to compile.
- rename eccp_curve_t structure.
- update TL721X pke header file.