### PR TITLE
telink: B92&TL321X: add exit latency mechanism.

### DIFF
--- a/tlsr9/ble/stack/ble/TL321X/controller/ll/ll_stack.h
+++ b/tlsr9/ble/stack/ble/TL321X/controller/ll/ll_stack.h
@@ -2146,8 +2146,8 @@ typedef struct {
 
     u32     appWakeup_tick;
 
-
-
+    u32     suspend_exitLatencyTick;
+    u32     deepret_exitLatencyTick;
 
     sch_task_t  *pTask_wakeup;
 

--- a/tlsr9/ble/vendor/controller/b9x/b9x_bt_init.c
+++ b/tlsr9/ble/vendor/controller/b9x/b9x_bt_init.c
@@ -35,6 +35,10 @@
 
 #ifdef CONFIG_PM
 #include "ext_driver/ext_pm.h"
+
+/** a temporary method to set exit latency which can be set in header files */
+#define SUSPEND_EXIT_LATENCY_US		(300U)
+#define DEEPRETN_EXIT_LATENCY_US	(1000U)
 #endif /* CONFIG_PM */
 
 #if CONFIG_TL_BLE_CTRL_EXT_ADV
@@ -213,6 +217,11 @@ int b9x_bt_blc_init(void *prx, void *ptx)
 	/* Enable the sleep masks for BLE stack thread */
 	blc_pm_setSleepMask(PM_SLEEP_LEG_ADV | PM_SLEEP_LEG_SCAN | PM_SLEEP_ACL_SLAVE |
 			    PM_SLEEP_ACL_MASTER);
+
+#if CONFIG_SOC_RISCV_TELINK_B92
+	extern void blc_ll_setOsLowPowerExitLatencyUs(uint32_t suspendUs, uint32_t deepretUs);
+	blc_ll_setOsLowPowerExitLatencyUs(SUSPEND_EXIT_LATENCY_US, DEEPRETN_EXIT_LATENCY_US);
+#endif
 #endif /* CONFIG_PM */
 
 	return INIT_OK;

--- a/tlsr9/ble/vendor/controller/tlx/tlx_bt_init.c
+++ b/tlsr9/ble/vendor/controller/tlx/tlx_bt_init.c
@@ -28,6 +28,10 @@
 
 #ifdef CONFIG_PM
 #include "ext_driver/ext_pm.h"
+
+/** a temporary method to set exit latency which can be set in header files */
+#define SUSPEND_EXIT_LATENCY_US		(200U)
+#define DEEPRETN_EXIT_LATENCY_US	(1000U)
 #endif /* CONFIG_PM */
 
 #if CONFIG_TL_BLE_CTRL_EXT_ADV
@@ -203,6 +207,11 @@ int tlx_bt_blc_init(void *prx, void *ptx)
 	/* Enable the sleep masks for BLE stack thread */
 	blc_pm_setSleepMask(PM_SLEEP_LEG_ADV | PM_SLEEP_LEG_SCAN | PM_SLEEP_ACL_SLAVE |
 			    PM_SLEEP_ACL_MASTER);
+
+	#if CONFIG_SOC_RISCV_TELINK_TL321X
+		extern void blc_ll_setOsLowPowerExitLatencyUs(uint32_t suspendUs, uint32_t deepretUs);
+		blc_ll_setOsLowPowerExitLatencyUs(SUSPEND_EXIT_LATENCY_US, DEEPRETN_EXIT_LATENCY_US);
+	#endif
 #endif /* CONFIG_PM */
 
 	return INIT_OK;

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -12,11 +12,11 @@ blobs:
     description: "Binary libraries supporting Telink B91 series BLE subsystems"
 
   - path: lib_zephyr_b92.a
-    sha256: 0933ceb0ba1fbd72798b2de0ad7781c2458351ee09bb0e7dae737c432d0d0f0e
+    sha256: 27a0efd6369cc1c143fb9f8cff5b3c3de17fd9e6a51161a52230287262574e56
     type: lib
-    version: 'tl-wiki-0002'
+    version: 'tl-wiki-0003'
     license-path: tlsr9/ble/license.txt
-    url: http://wiki.telink-semi.cn/wiki/protocols/Zephyr/binaries/public/b92_lib/lib_zephyr_b92_2e7590923f3df6b8882a04eccaa71ebe2f241b99.a
+    url: http://wiki.telink-semi.cn/wiki/protocols/Zephyr/binaries/public/b92_lib/lib_zephyr_b92_2c49466f2431e210e62dd566a85791ea260dbb51.a
     description: "Binary libraries supporting Telink B92 series BLE subsystems"
 
   - path: lib_zephyr_b95.a


### PR DESCRIPTION
- add suspend & deepretn exit latency mechanism to avoid BLE disconn issue.

Signed-off-by: ZhihanTao <zhihan.tao@telink-semi.com>
(cherry picked from commit 8a1d5139c77072e7dd13336f5db578583e0ef913)