### PR TITLE
telink: B92: add exit latency mechanism.

### DIFF
--- a/tlsr9/ble/vendor/controller/b9x/b9x_bt_init.c
+++ b/tlsr9/ble/vendor/controller/b9x/b9x_bt_init.c
@@ -35,6 +35,10 @@
 
 #ifdef CONFIG_PM
 #include "ext_driver/ext_pm.h"
+
+/** a temporary method to set exit latency which can be set in header files */
+#define SUSPEND_EXIT_LATENCY_US		(300U)
+#define DEEPRETN_EXIT_LATENCY_US	(1000U)
 #endif /* CONFIG_PM */
 
 #if CONFIG_TL_BLE_CTRL_EXT_ADV
@@ -213,6 +217,11 @@ int b9x_bt_blc_init(void *prx, void *ptx)
 	/* Enable the sleep masks for BLE stack thread */
 	blc_pm_setSleepMask(PM_SLEEP_LEG_ADV | PM_SLEEP_LEG_SCAN | PM_SLEEP_ACL_SLAVE |
 			    PM_SLEEP_ACL_MASTER);
+
+#if CONFIG_SOC_RISCV_TELINK_B92
+	extern void blc_ll_setOsLowPowerExitLatencyUs(uint32_t suspendUs, uint32_t deepretUs);
+	blc_ll_setOsLowPowerExitLatencyUs(SUSPEND_EXIT_LATENCY_US, DEEPRETN_EXIT_LATENCY_US);
+#endif
 #endif /* CONFIG_PM */
 
 	return INIT_OK;

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -12,11 +12,11 @@ blobs:
     description: "Binary libraries supporting Telink B91 series BLE subsystems"
 
   - path: lib_zephyr_b92.a
-    sha256: 0933ceb0ba1fbd72798b2de0ad7781c2458351ee09bb0e7dae737c432d0d0f0e
+    sha256: dee959cd330d003fe6d0886af3ac151e187d70ffa83ae5e469bfff9ad3e083ba
     type: lib
     version: 'tl-wiki-0002'
     license-path: tlsr9/ble/license.txt
-    url: http://wiki.telink-semi.cn/wiki/protocols/Zephyr/binaries/public/b92_lib/lib_zephyr_b92_2e7590923f3df6b8882a04eccaa71ebe2f241b99.a
+    url: http://wiki.telink-semi.cn/wiki/protocols/Zephyr/binaries/public/b92_lib/lib_zephyr_b92_60ee93696be87a14b06f67a938aa8c9efaa0fc42.a
     description: "Binary libraries supporting Telink B92 series BLE subsystems"
 
   - path: lib_zephyr_b95.a


### PR DESCRIPTION
- add suspend & deepretn exit latency mechanism to avoid BLE disconn issue.

Signed-off-by: Zhihan Tao <zhihan.tao@telink-semi.com>