### PR TITLE
telink: B92&TL321X: add exit latency mechanism.

### DIFF
--- a/tlsr9/ble/stack/ble/TL321X/controller/ll/ll_stack.h
+++ b/tlsr9/ble/stack/ble/TL321X/controller/ll/ll_stack.h
@@ -2146,8 +2146,8 @@ typedef struct {
 
     u32     appWakeup_tick;
 
-
-
+    u32     suspend_exitLatencyTick;
+    u32     deepret_exitLatencyTick;
 
     sch_task_t  *pTask_wakeup;
 

--- a/tlsr9/ble/vendor/controller/b9x/b9x_bt_init.c
+++ b/tlsr9/ble/vendor/controller/b9x/b9x_bt_init.c
@@ -35,6 +35,10 @@
 
 #ifdef CONFIG_PM
 #include "ext_driver/ext_pm.h"
+
+/** a temporary method to set exit latency which can be set in header files */
+#define SUSPEND_EXIT_LATENCY_US		(300U)
+#define DEEPRETN_EXIT_LATENCY_US	(1000U)
 #endif /* CONFIG_PM */
 
 #if CONFIG_TL_BLE_CTRL_EXT_ADV
@@ -213,6 +217,11 @@ int b9x_bt_blc_init(void *prx, void *ptx)
 	/* Enable the sleep masks for BLE stack thread */
 	blc_pm_setSleepMask(PM_SLEEP_LEG_ADV | PM_SLEEP_LEG_SCAN | PM_SLEEP_ACL_SLAVE |
 			    PM_SLEEP_ACL_MASTER);
+
+#if CONFIG_SOC_RISCV_TELINK_B92
+	extern void blc_ll_setOsLowPowerExitLatencyUs(uint32_t suspendUs, uint32_t deepretUs);
+	blc_ll_setOsLowPowerExitLatencyUs(SUSPEND_EXIT_LATENCY_US, DEEPRETN_EXIT_LATENCY_US);
+#endif
 #endif /* CONFIG_PM */
 
 	return INIT_OK;

--- a/tlsr9/ble/vendor/controller/tlx/tlx_bt_init.c
+++ b/tlsr9/ble/vendor/controller/tlx/tlx_bt_init.c
@@ -28,6 +28,10 @@
 
 #ifdef CONFIG_PM
 #include "ext_driver/ext_pm.h"
+
+/** a temporary method to set exit latency which can be set in header files */
+#define SUSPEND_EXIT_LATENCY_US		(200U)
+#define DEEPRETN_EXIT_LATENCY_US	(1000U)
 #endif /* CONFIG_PM */
 
 #if CONFIG_TL_BLE_CTRL_EXT_ADV
@@ -203,6 +207,11 @@ int tlx_bt_blc_init(void *prx, void *ptx)
 	/* Enable the sleep masks for BLE stack thread */
 	blc_pm_setSleepMask(PM_SLEEP_LEG_ADV | PM_SLEEP_LEG_SCAN | PM_SLEEP_ACL_SLAVE |
 			    PM_SLEEP_ACL_MASTER);
+
+	#if CONFIG_SOC_RISCV_TELINK_TL321X
+		extern void blc_ll_setOsLowPowerExitLatencyUs(uint32_t suspendUs, uint32_t deepretUs);
+		blc_ll_setOsLowPowerExitLatencyUs(SUSPEND_EXIT_LATENCY_US, DEEPRETN_EXIT_LATENCY_US);
+	#endif
 #endif /* CONFIG_PM */
 
 	return INIT_OK;

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -12,11 +12,11 @@ blobs:
     description: "Binary libraries supporting Telink B91 series BLE subsystems"
 
   - path: lib_zephyr_b92.a
-    sha256: 0933ceb0ba1fbd72798b2de0ad7781c2458351ee09bb0e7dae737c432d0d0f0e
+    sha256: dee959cd330d003fe6d0886af3ac151e187d70ffa83ae5e469bfff9ad3e083ba
     type: lib
-    version: 'tl-wiki-0002'
+    version: 'tl-wiki-0003'
     license-path: tlsr9/ble/license.txt
-    url: http://wiki.telink-semi.cn/wiki/protocols/Zephyr/binaries/public/b92_lib/lib_zephyr_b92_2e7590923f3df6b8882a04eccaa71ebe2f241b99.a
+    url: http://wiki.telink-semi.cn/wiki/protocols/Zephyr/binaries/public/b92_lib/lib_zephyr_b92_60ee93696be87a14b06f67a938aa8c9efaa0fc42.a
     description: "Binary libraries supporting Telink B92 series BLE subsystems"
 
   - path: lib_zephyr_b95.a
@@ -28,17 +28,17 @@ blobs:
     description: "Binary libraries supporting Telink B95 series BLE subsystems"
 
   - path: lib_zephyr_tl321x.a
-    sha256: 8e4e9a52f5e2ce7e422504f9459434c0ba808705b65c7ab32d3feedc1c6f315c
+    sha256: f968ecadbe71aa584c48e85dc3f65a444a91e67c78dbd6890014f20944d46209
     type: lib
     version: 'V4.0.4.2'
     license-path: tlsr9/ble/license.txt
-    url: http://wiki.telink-semi.cn/wiki/protocols/Zephyr/binaries/public/tl321x_lib/lib_zephyr_tl321x_6b70d4a9176d8c73a93e364f9d800821a5aa5eeb.a
+    url: http://wiki.telink-semi.cn/wiki/protocols/Zephyr/binaries/public/tl321x_lib/lib_zephyr_tl321x_f1f79fc37849c5e6a51758a5c532f1fa45bbb838.a
     description: "Binary libraries supporting Telink TL321X series BLE subsystems"
 
   - path: lib_zephyr_tl321x_pm.a
-    sha256: 43ba1e1cb46af52732cd67bc9708cf3bd9456e8aae0a35bdb7ed53f160ed8f05
+    sha256: 8b2637025c69b8cdf6b57a643a0e212bdfbc1e7f7dd84f7965518353e70b6fd3
     type: lib
     version: 'V4.0.4.2'
     license-path: tlsr9/ble/license.txt
-    url: http://wiki.telink-semi.cn/wiki/protocols/Zephyr/binaries/public/tl321x_lib/lib_zephyr_tl321x_6b70d4a9176d8c73a93e364f9d800821a5aa5eeb_pm.a
+    url: http://wiki.telink-semi.cn/wiki/protocols/Zephyr/binaries/public/tl321x_lib/lib_zephyr_tl321x_f1f79fc37849c5e6a51758a5c532f1fa45bbb838_pm.a
     description: "Binary libraries for the Telink TL321X series BLE subsystems, optimized for low-power mode"


### PR DESCRIPTION
- add suspend & deepretn exit latency mechanism to avoid BLE disconn issue.

Signed-off-by: Zhihan Tao <zhihan.tao@telink-semi.com>