### PR TITLE
telink: TL721X: add exit latency mechanism.

### DIFF
--- a/tlsr9/ble/stack/ble/TL321X/controller/ll/ll_stack.h
+++ b/tlsr9/ble/stack/ble/TL321X/controller/ll/ll_stack.h
@@ -2146,7 +2146,8 @@ typedef struct {
 
     u32     appWakeup_tick;
 
-
+    u32     suspend_exitLatencyTick;
+    u32     deepret_exitLatencyTick;
 
 
     sch_task_t  *pTask_wakeup;

--- a/tlsr9/ble/vendor/controller/tlx/tlx_bt_init.c
+++ b/tlsr9/ble/vendor/controller/tlx/tlx_bt_init.c
@@ -66,6 +66,15 @@ _attribute_ble_data_retention_ u8
 
 #endif /* CONFIG_TL_BLE_CTRL_PER_ADV */
 
+/** a temporary method to set exit latency which can be set in header files */
+#if CONFIG_SOC_RISCV_TELINK_TL321X
+	#define SUSPEND_EXIT_LATENCY_US		(200U)
+	#define DEEPRETN_EXIT_LATENCY_US	(1000U)		/*!< Not used for now */
+#elif CONFIG_SOC_RISCV_TELINK_TL721X
+	#define SUSPEND_EXIT_LATENCY_US		(250U)
+	#define DEEPRETN_EXIT_LATENCY_US	(0U)		/*!< Not used for now */
+#endif
+
 /**
  * @brief       Telink TLX BLE Controller initialization
  * @param[in]   prx - HCI RX callback
@@ -207,6 +216,11 @@ int tlx_bt_blc_init(void *prx, void *ptx)
 	blc_pm_setSleepMask(PM_SLEEP_LEG_ADV | PM_SLEEP_LEG_SCAN | PM_SLEEP_ACL_SLAVE |
 			    PM_SLEEP_ACL_MASTER);
 #endif /* CONFIG_PM */
+
+#if CONFIG_SOC_RISCV_TELINK_TL321X || CONFIG_SOC_RISCV_TELINK_TL721X
+	extern void blc_ll_setOsLowPowerExitLatencyUs(uint32_t suspendUs, uint32_t deepretUs);
+	blc_ll_setOsLowPowerExitLatencyUs(SUSPEND_EXIT_LATENCY_US, DEEPRETN_EXIT_LATENCY_US);
+#endif
 
 	return INIT_OK;
 }


### PR DESCRIPTION
- add suspend & deepretn exit latency mechanism to avoid BLE disconn issue.

Signed-off-by: Zhihan Tao <zhihan.tao@telink-semi.com>