### PR TITLE
hal: telink: tlsr9528a: update HAL for tlsr9528a

### DIFF
--- a/tlsr9/drivers/B92/clock.c
+++ b/tlsr9/drivers/B92/clock.c
@@ -399,7 +399,7 @@ void clock_init(sys_pll_clk_e pll,
  * @param[in]   cclk_hclk_pclk - frequency of CCLK/HCLK/PCLK.
  * @return      none
  */
-void cclk_hclk_pclk_config(pll_div_cclk_hclk_pclk_e div)
+_attribute_ram_code_com_sec_noinline_ void cclk_hclk_pclk_config(pll_div_cclk_hclk_pclk_e div)
 {
 	unsigned char cclk_div = div>>8;
 	unsigned char hclk_div = (div&0x00f0)>>4;

--- a/tlsr9/drivers/B92/clock.h
+++ b/tlsr9/drivers/B92/clock.h
@@ -58,7 +58,7 @@
 #define CCLK_32M_HCLK_32M_PCLK_16M			clock_init(PLL_CLK_192M, PAD_PLL_DIV, PLL_DIV6_TO_CCLK, CCLK_DIV1_TO_HCLK, HCLK_DIV2_TO_PCLK, PLL_DIV4_TO_MSPI_CLK)
 #define CCLK_48M_HCLK_48M_PCLK_24M			clock_init(PLL_CLK_192M, PAD_PLL_DIV, PLL_DIV4_TO_CCLK, CCLK_DIV1_TO_HCLK, HCLK_DIV2_TO_PCLK, PLL_DIV4_TO_MSPI_CLK)
 #define CCLK_96M_HCLK_48M_PCLK_24M			clock_init(PLL_CLK_192M, PAD_PLL_DIV, PLL_DIV2_TO_CCLK, CCLK_DIV2_TO_HCLK, HCLK_DIV2_TO_PCLK, PLL_DIV4_TO_MSPI_CLK)
-
+#define CCLK_96M_HCLK_48M_PCLK_24M_MSPI_64M	clock_init(PLL_CLK_192M, PAD_PLL_DIV, PLL_DIV2_TO_CCLK, CCLK_DIV2_TO_HCLK, HCLK_DIV2_TO_PCLK, PLL_DIV3_TO_MSPI_CLK)
 /**********************************************************************************************************************
  *                                         global data type                                                           *
  *********************************************************************************************************************/


### PR DESCRIPTION
add a macro to support MSPI 64M