### PR TITLE
hal: telink: zephyr versions compatibility changes

### DIFF
--- a/tlsr9/CMakeLists.txt
+++ b/tlsr9/CMakeLists.txt
@@ -46,7 +46,7 @@ if (CONFIG_SOC_RISCV_TELINK_B92)
 endif()
 
 # add for TLX headers
-if (CONFIG_SOC_SERIES_RISCV_TELINK_TLX OR CONFIG_SOC_RISCV_TELINK_TLX)
+if (CONFIG_SOC_RISCV_TELINK_TLX)
 	zephyr_include_directories(
 		drivers/${SOC}/lib/include/rf
 		drivers/${SOC}/lib/include/ske
@@ -55,7 +55,7 @@ if (CONFIG_SOC_SERIES_RISCV_TELINK_TLX OR CONFIG_SOC_RISCV_TELINK_TLX)
 endif()
 
 # add for TLX or B9X headers
-if (CONFIG_SOC_SERIES_RISCV_TELINK_TLX OR CONFIG_SOC_RISCV_TELINK_TLX)
+if (CONFIG_SOC_RISCV_TELINK_TLX)
 	zephyr_include_directories(drivers/${SOC}/ext_driver/driver_internal)
 elseif(CONFIG_SOC_SERIES_RISCV_TELINK_B9X)
 	zephyr_include_directories(drivers/${SOC}/ext_driver/driver_lib)
@@ -64,7 +64,7 @@ endif()
 endif() # NOT CONFIG_SOC_RISCV_TELINK_B91
 
 # soc.c reference sources for B9X
-if (NOT (CONFIG_SOC_SERIES_RISCV_TELINK_TLX OR CONFIG_SOC_RISCV_TELINK_TLX))
+if (NOT CONFIG_SOC_RISCV_TELINK_TLX)
 	zephyr_library_sources(drivers/${SOC}/clock.c)
 	zephyr_library_sources(drivers/${SOC}/analog.c)
 endif()
@@ -131,7 +131,7 @@ endif()
 #PM driver dependency
 if(CONFIG_PM)
 	zephyr_library_sources(common/tl_sleep.c)
-	zephyr_library_sources_ifdef(NOT (CONFIG_SOC_SERIES_RISCV_TELINK_TLX OR CONFIG_SOC_RISCV_TELINK_TLX)
+	zephyr_library_sources_ifdef(NOT CONFIG_SOC_RISCV_TELINK_TLX
 		drivers/${SOC}/stimer.c
 	)
 endif()
@@ -159,7 +159,7 @@ if (CONFIG_BT_B9X OR CONFIG_BT_TLX)
 	)
 endif() # CONFIG_BT_B9X OR CONFIG_BT_TLX
 
-if (CONFIG_SOC_SERIES_RISCV_TELINK_TLX OR CONFIG_SOC_RISCV_TELINK_TLX)
+if (CONFIG_SOC_RISCV_TELINK_TLX)
 	add_definitions(-DSTD_GCC)
 endif()
 
@@ -168,6 +168,6 @@ if (CONFIG_SOC_SERIES_RISCV_TELINK_B9X_RETENTION OR CONFIG_SOC_SERIES_RISCV_TELI
 	zephyr_library_sources(common/tl_context.S)
 endif()
 
-if (CONFIG_SOC_SERIES_RISCV_TELINK_TLX OR CONFIG_SOC_RISCV_TELINK_TLX)
+if (CONFIG_SOC_RISCV_TELINK_TLX)
 	target_compile_options(${ZEPHYR_CURRENT_LIBRARY} PRIVATE -flto=auto)
 endif()

--- a/tlsr9/crypto/mbedtls/mbedtls_wrapper.c
+++ b/tlsr9/crypto/mbedtls/mbedtls_wrapper.c
@@ -15,7 +15,7 @@
  * ECP HW accelerated functions
  *********************************************************************/
 
-#if CONFIG_SOC_SERIES_RISCV_TELINK_TLX || CONFIG_SOC_RISCV_TELINK_TLX
+#if CONFIG_SOC_RISCV_TELINK_TLX
 extern int telink_tlx_ecp_check_pubkey(const mbedtls_ecp_group *grp,
 	const mbedtls_ecp_point *pt);
 extern int telink_tlx_ecp_mul_restartable(mbedtls_ecp_group *grp,
@@ -27,7 +27,7 @@ extern int telink_tlx_ecp_muladd_restartable(mbedtls_ecp_group *grp,
 	const mbedtls_mpi *m, const mbedtls_ecp_point *P,
 	const mbedtls_mpi *n, const mbedtls_ecp_point *Q,
 	mbedtls_ecp_restart_ctx *rs_ctx);
-#elif CONFIG_SOC_SERIES_RISCV_TELINK_B9X || CONFIG_SOC_RISCV_TELINK_B9X
+#elif CONFIG_SOC_RISCV_TELINK_B9X
 extern int telink_b9x_ecp_check_pubkey(const mbedtls_ecp_group *grp,
 	const mbedtls_ecp_point *pt);
 extern int telink_b9x_ecp_mul_restartable(mbedtls_ecp_group *grp,
@@ -70,9 +70,9 @@ extern int __real_mbedtls_ecp_self_test(int verbose);
 int __wrap_mbedtls_ecp_check_pubkey(const mbedtls_ecp_group *grp,
 	const mbedtls_ecp_point *pt)
 {
-#if CONFIG_SOC_SERIES_RISCV_TELINK_TLX || CONFIG_SOC_RISCV_TELINK_TLX
+#if CONFIG_SOC_RISCV_TELINK_TLX
 	int result = telink_tlx_ecp_check_pubkey(grp, pt);
-#elif CONFIG_SOC_SERIES_RISCV_TELINK_B9X || CONFIG_SOC_RISCV_TELINK_B9X
+#elif CONFIG_SOC_RISCV_TELINK_B9X
 	int result = telink_b9x_ecp_check_pubkey(grp, pt);
 #endif
 
@@ -87,9 +87,9 @@ int __wrap_mbedtls_ecp_mul_restartable(mbedtls_ecp_group *grp,
 	int (*f_rng)(void *, unsigned char *, size_t),
 	void *p_rng, mbedtls_ecp_restart_ctx *rs_ctx)
 {
-#if CONFIG_SOC_SERIES_RISCV_TELINK_TLX || CONFIG_SOC_RISCV_TELINK_TLX
+#if CONFIG_SOC_RISCV_TELINK_TLX
 	int result = telink_tlx_ecp_mul_restartable(grp, R, m, P, f_rng, p_rng, rs_ctx);
-#elif CONFIG_SOC_SERIES_RISCV_TELINK_B9X || CONFIG_SOC_RISCV_TELINK_B9X
+#elif CONFIG_SOC_RISCV_TELINK_B9X
 	int result = telink_b9x_ecp_mul_restartable(grp, R, m, P, f_rng, p_rng, rs_ctx);
 #endif
 
@@ -112,9 +112,9 @@ int __wrap_mbedtls_ecp_muladd_restartable(mbedtls_ecp_group *grp,
 	const mbedtls_mpi *n, const mbedtls_ecp_point *Q,
 	mbedtls_ecp_restart_ctx *rs_ctx)
 {
-#if CONFIG_SOC_SERIES_RISCV_TELINK_TLX || CONFIG_SOC_RISCV_TELINK_TLX
+#if CONFIG_SOC_RISCV_TELINK_TLX
 	int result = telink_tlx_ecp_muladd_restartable(grp, R, m, P, n, Q, rs_ctx);
-#elif CONFIG_SOC_SERIES_RISCV_TELINK_B9X || CONFIG_SOC_RISCV_TELINK_B9X
+#elif CONFIG_SOC_RISCV_TELINK_B9X
 	int result = telink_b9x_ecp_muladd_restartable(grp, R, m, P, n, Q, rs_ctx);
 #endif
 


### PR DESCRIPTION
- use common SOC configs for different Zephyr versions