### PR TITLE
telink: TL7218X: change macro SUSPEND_EXIT_LATENCY_US .

### DIFF
--- a/tlsr9/ble/vendor/controller/tlx/tlx_bt_init.c
+++ b/tlsr9/ble/vendor/controller/tlx/tlx_bt_init.c
@@ -71,7 +71,7 @@ _attribute_ble_data_retention_ u8
 	#define SUSPEND_EXIT_LATENCY_US		(200U)
 	#define DEEPRETN_EXIT_LATENCY_US	(1000U)		/*!< Not used for now */
 #elif CONFIG_SOC_RISCV_TELINK_TL721X
-	#define SUSPEND_EXIT_LATENCY_US		(250U)
+	#define SUSPEND_EXIT_LATENCY_US		(150U)
 	#define DEEPRETN_EXIT_LATENCY_US	(0U)		/*!< Not used for now */
 #endif
 


### PR DESCRIPTION
- For 80MHz sysclk, change macro SUSPEND_EXIT_LATENCY_US form 250us to 150us, For 60MHz, SUSPEND_EXIT_LATENCY_US  should be 250us.
- This parameter should be measured by ellisys bluetooth analyzer, a better solution should be proposed later.