### PR TITLE
hal: telink: Exclude mip csr from retention backup

### DIFF
--- a/tlsr9/common/tl_context.S
+++ b/tlsr9/common/tl_context.S
@@ -71,7 +71,7 @@ SECTION_VAR(retention_data, tl_context_backup_registers)
  * 37 - mstatus
  * 38 - mxstatus
  * 39 - mdcause
- * 40 - mip
+ * 40 - reserved
  * 41 - mie
  * 42 -  f0 - ft0
  * 43 -  f1 - ft1
@@ -184,9 +184,6 @@ SECTION_FUNC(ram_code, tl_context_save)
 	csrr   x31, mdcause
 	sw     x31, (39 * 4)(x30)
 
-	csrr   x31, mip
-	sw     x31, (40 * 4)(x30)
-
 	csrr   x31, mie
 	sw     x31, (41 * 4)(x30)
 
@@ -273,9 +270,6 @@ SECTION_FUNC(ram_code, tl_context_restore)
 
 	lw     x30, (39 * 4)(x31)
 	csrw   mdcause, x30
-
-	lw     x30, (40 * 4)(x31)
-	csrw   mip, x30
 
 	lw     x30, (41 * 4)(x31)
 	csrw   mie, x30


### PR DESCRIPTION
Before entering any sleep mode we have globally disabled ISRs. But ISR can happened during this time and it leads to set mip csr (notification about ISR). Usually this pending ISR will be handled after global interrupt enabling. In case of deep-sleep all digital peripheral is resettled including PLIC. As result after leaving deep-sleep mode pending ISRs was restored in mip csr so it triggers corresponding ISRs after their global enabling. But peripheral and PLIC has been resettled.
It was lead to spurious interrupt with PLIC number zero. For now mip csr is no longer saved anyway due to peripheral reset there is no chance to handle such events.