### PR TITLE
MCUBoot Hardware SHA256 Acceleration for TLX

### DIFF
--- a/hal_v1/tlsr9/crypto/mbedtls/CMakeLists.txt
+++ b/hal_v1/tlsr9/crypto/mbedtls/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2024, Telink
+# Copyright (c) 2022-2025, Telink
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -33,6 +33,30 @@ zephyr_library_sources_ifdef(CONFIG_TELINK_B9X_MBEDTLS_HW_ACCELERATION
 zephyr_library_sources_ifdef(CONFIG_TELINK_TLX_MBEDTLS_HW_ACCELERATION 
 	./ecp_tlx_backend.c
 )
+
+# Include TLX drivers for accelerated SHA256, linker wraps
+if(CONFIG_TELINK_TLX_MBEDTLS_HW_SHA_ACCELERATION)
+	message(STATUS "HW SHA configured")
+
+	zephyr_include_directories(
+		${ZEPHYR_HAL_TELINK_MODULE_DIR}/tlsr9/drivers/${SOC}/lib/include
+		${ZEPHYR_HAL_TELINK_MODULE_DIR}/tlsr9/drivers/${SOC}/lib/include/hash
+	)
+
+	zephyr_library_sources( 
+		./sha256_tlx_backend.c
+	)
+
+	zephyr_link_libraries(
+		-Wl,--wrap,mbedtls_sha256_init
+		-Wl,--wrap,mbedtls_sha256_starts
+		-Wl,--wrap,mbedtls_sha256_update
+		-Wl,--wrap,mbedtls_sha256_finish
+		-Wl,--wrap,mbedtls_sha256_free
+		-Wl,--wrap=mbedtls_sha256
+		-Wl,--wrap=mbedtls_sha256_clone
+	)
+endif() # CONFIG_TELINK_TLX_MBEDTLS_HW_SHA_ACCELERATION
 
 zephyr_link_libraries(
 	-Wl,--wrap,mbedtls_ecp_check_pubkey

--- a/hal_v1/tlsr9/crypto/mbedtls/mbedtls_wrapper.c
+++ b/hal_v1/tlsr9/crypto/mbedtls/mbedtls_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Telink Semiconductor
+ * Copyright (c) 2024-2025 Telink Semiconductor
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -44,10 +44,37 @@ extern int telink_b9x_ecp_muladd_restartable(mbedtls_ecp_group *grp,
 extern int telink_soc_ecp_self_test(int verbose);
 #endif /* MBEDTLS_SELF_TEST */
 
+#endif /* MBEDTLS_ECP_C */
+
+/*********************************************************************
+ * SHA256 HW accelerated functions
+ *********************************************************************/
+
+#ifdef MBEDTLS_SHA256_C
+
+#include <mbedtls/sha256.h>
+
+#if CONFIG_TELINK_TLX_MBEDTLS_HW_SHA_ACCELERATION
+extern void telink_tlx_sha256_init(mbedtls_sha256_context *ctx);
+extern int telink_tlx_sha256_starts(mbedtls_sha256_context *ctx, int is224);
+extern int telink_tlx_sha256_update(mbedtls_sha256_context *ctx,
+                                     const unsigned char *input,
+                                     size_t ilen);
+extern int telink_tlx_sha256_finish(mbedtls_sha256_context *ctx,
+                                     unsigned char output[32]);
+extern void telink_tlx_sha256_free(mbedtls_sha256_context *ctx);
+
+extern void telink_tlx_sha256_clone(mbedtls_sha256_context *dst,
+                                  const mbedtls_sha256_context *src);
+#endif /* CONFIG_TELINK_TLX_MBEDTLS_HW_SHA_ACCELERATION */
+
+#endif /* MBEDTLS_SHA256_C */
+
 /*********************************************************************
  * LD transformed software functions
  *********************************************************************/
 
+#ifdef MBEDTLS_ECP_C
 extern int __real_mbedtls_ecp_check_pubkey(const mbedtls_ecp_group *grp,
 	const mbedtls_ecp_point *pt);
 extern int __real_mbedtls_ecp_mul_restartable(mbedtls_ecp_group *grp,
@@ -62,10 +89,13 @@ extern int __real_mbedtls_ecp_muladd_restartable(mbedtls_ecp_group *grp,
 #ifdef MBEDTLS_SELF_TEST
 extern int __real_mbedtls_ecp_self_test(int verbose);
 #endif /* MBEDTLS_SELF_TEST */
+#endif /* MBEDTLS_ECP_C */
 
 /*********************************************************************
  * Call HW accelerated functionality if fails use software
  *********************************************************************/
+
+#ifdef MBEDTLS_ECP_C
 
 int __wrap_mbedtls_ecp_check_pubkey(const mbedtls_ecp_group *grp,
 	const mbedtls_ecp_point *pt)
@@ -182,3 +212,75 @@ int __wrap_mbedtls_ecp_self_test(int verbose)
 #endif /* MBEDTLS_SELF_TEST */
 
 #endif /* MBEDTLS_ECP_C */
+
+/*********************************************************************
+ * SHA256 wrapper functions
+ *********************************************************************/
+
+#ifdef MBEDTLS_SHA256_C
+
+#ifdef CONFIG_TELINK_TLX_MBEDTLS_HW_SHA_ACCELERATION
+void __wrap_mbedtls_sha256_init(mbedtls_sha256_context *ctx)
+{
+	telink_tlx_sha256_init(ctx);
+}
+
+int __wrap_mbedtls_sha256_starts(mbedtls_sha256_context *ctx, int is224)
+{
+	return telink_tlx_sha256_starts(ctx, is224);
+}
+
+int __wrap_mbedtls_sha256_update(mbedtls_sha256_context *ctx,
+                                  const unsigned char *input,
+                                  size_t ilen)
+{
+	return telink_tlx_sha256_update(ctx, input, ilen);;
+}
+
+int __wrap_mbedtls_sha256_finish(mbedtls_sha256_context *ctx,
+                                  unsigned char output[32])
+{
+	return telink_tlx_sha256_finish(ctx, output);
+}
+
+void __wrap_mbedtls_sha256_free(mbedtls_sha256_context *ctx)
+{
+	telink_tlx_sha256_free(ctx);
+}
+
+void __wrap_mbedtls_sha256_clone(mbedtls_sha256_context *dst,
+                                  const mbedtls_sha256_context *src)
+{
+    telink_tlx_sha256_clone(dst, src);
+}
+
+int __wrap_mbedtls_sha256(const unsigned char *input,
+                           size_t ilen,
+                           unsigned char output[32],
+                           int is224)
+{
+    mbedtls_sha256_context ctx;
+    int ret;
+
+    __wrap_mbedtls_sha256_init(&ctx);
+
+    ret = __wrap_mbedtls_sha256_starts(&ctx, is224);
+    if (ret != 0) {
+        goto exit;
+    }
+
+    ret = __wrap_mbedtls_sha256_update(&ctx, input, ilen);
+    if (ret != 0) {
+        goto exit;
+    }
+
+    ret = __wrap_mbedtls_sha256_finish(&ctx, output);
+
+exit:
+    __wrap_mbedtls_sha256_free(&ctx);
+    return ret;
+}
+
+#endif /* CONFIG_TELINK_TLX_MBEDTLS_HW_SHA_ACCELERATION */
+
+#endif /* MBEDTLS_SHA256_C */

--- a/hal_v1/tlsr9/crypto/mbedtls/sha256_tlx_backend.c
+++ b/hal_v1/tlsr9/crypto/mbedtls/sha256_tlx_backend.c
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2025 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file sha256_tlx_backend.c
+ * @brief TLX hardware-accelerated SHA256 backend for mbedTLS
+ */
+
+#include <string.h>
+#include <mbedtls/sha256.h>
+#include <mbedtls/error.h>
+#include <zephyr/kernel.h>
+#include <zephyr/spinlock.h>
+
+#include "hash/hash_portable.h"
+#include "hash/sha256.h"
+
+/* Max concurrent SHA256 contexts */
+#define MAX_SHA256_CONTEXTS    8
+
+typedef struct {
+    mbedtls_sha256_context *owner;
+    SHA256_CTX hw_ctx;
+    uint32_t iterator[HASH_ITERATOR_MAX_WORD_LEN];
+    bool in_use;
+    bool started;
+} sha256_slot_t;
+
+static sha256_slot_t g_slots[MAX_SHA256_CONTEXTS];
+
+/* Protects slot table + g_hw_active_slot only */
+static struct k_spinlock g_slots_lock;
+
+/* Serializes access to the HW SHA engine */
+static struct k_mutex g_hw_mutex;
+
+static sha256_slot_t *g_hw_active_slot;
+
+/* ---------- HW context save / restore ---------- */
+
+static void save_hw_state(sha256_slot_t *slot)
+{
+    if (slot && slot->started) {
+        hash_get_iterator((unsigned char *)slot->iterator,
+                          HASH_ITERATOR_MAX_WORD_LEN);
+    }
+}
+
+static void restore_hw_state(sha256_slot_t *slot)
+{
+    if (slot && slot->started) {
+        hash_set_iterator(slot->iterator,
+                          HASH_ITERATOR_MAX_WORD_LEN);
+    }
+}
+
+/*
+ * Must be called with g_slots_lock held
+ */
+static void acquire_hw_locked(sha256_slot_t *slot)
+{
+    if (g_hw_active_slot == slot) {
+        return;
+    }
+
+    if (g_hw_active_slot) {
+        save_hw_state(g_hw_active_slot);
+    }
+
+    restore_hw_state(slot);
+    g_hw_active_slot = slot;
+}
+
+/* ---------- Slot management ---------- */
+
+static sha256_slot_t *get_slot(mbedtls_sha256_context *ctx, bool allocate)
+{
+    k_spinlock_key_t key = k_spin_lock(&g_slots_lock);
+    sha256_slot_t *free_slot = NULL;
+
+    for (int i = 0; i < MAX_SHA256_CONTEXTS; i++) {
+        if (g_slots[i].in_use) {
+            if (g_slots[i].owner == ctx) {
+                k_spin_unlock(&g_slots_lock, key);
+                return &g_slots[i];
+            }
+        } else if (!free_slot) {
+            free_slot = &g_slots[i];
+        }
+    }
+
+    if (allocate && free_slot) {
+        memset(free_slot, 0, sizeof(*free_slot));
+        free_slot->in_use = true;
+        free_slot->owner = ctx;
+        k_spin_unlock(&g_slots_lock, key);
+        return free_slot;
+    }
+
+    k_spin_unlock(&g_slots_lock, key);
+    return NULL;
+}
+
+static void release_slot(mbedtls_sha256_context *ctx)
+{
+    k_spinlock_key_t key = k_spin_lock(&g_slots_lock);
+
+    for (int i = 0; i < MAX_SHA256_CONTEXTS; i++) {
+        if (g_slots[i].in_use && g_slots[i].owner == ctx) {
+            if (g_hw_active_slot == &g_slots[i]) {
+                g_hw_active_slot = NULL;
+            }
+            memset(&g_slots[i], 0, sizeof(g_slots[i]));
+            break;
+        }
+    }
+
+    k_spin_unlock(&g_slots_lock, key);
+}
+
+/* ---------- mbedTLS backend API ---------- */
+
+void telink_tlx_sha256_init(mbedtls_sha256_context *ctx)
+{
+    release_slot(ctx);
+}
+
+int telink_tlx_sha256_starts(mbedtls_sha256_context *ctx, int is224)
+{
+    if (is224) {
+        return MBEDTLS_ERR_SHA256_BAD_INPUT_DATA;
+    }
+
+    sha256_slot_t *slot = get_slot(ctx, false);
+    if (!slot) {
+        slot = get_slot(ctx, true);
+        if (!slot) {
+            return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
+        }
+    }
+
+    /* Serialize HW access */
+    k_mutex_lock(&g_hw_mutex, K_FOREVER);
+
+    hash_dig_en();
+
+    if (sha256_init(&slot->hw_ctx) != 0) {
+        k_mutex_unlock(&g_hw_mutex);
+        release_slot(ctx);
+        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
+    }
+
+    slot->started = true;
+
+    /* Switch HW context */
+    k_spinlock_key_t key = k_spin_lock(&g_slots_lock);
+    acquire_hw_locked(slot);
+    k_spin_unlock(&g_slots_lock, key);
+
+    k_mutex_unlock(&g_hw_mutex);
+    return 0;
+}
+
+int telink_tlx_sha256_update(mbedtls_sha256_context *ctx,
+                            const unsigned char *input,
+                            size_t ilen)
+{
+    if (ilen == 0) {
+        return 0;
+    }
+
+    sha256_slot_t *slot = get_slot(ctx, false);
+    if (!slot || !slot->started) {
+        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
+    }
+
+    k_mutex_lock(&g_hw_mutex, K_FOREVER);
+
+    k_spinlock_key_t key = k_spin_lock(&g_slots_lock);
+    acquire_hw_locked(slot);
+    k_spin_unlock(&g_slots_lock, key);
+
+    int rc = sha256_update(&slot->hw_ctx,
+                           (unsigned char *)input,
+                           ilen);
+
+    key = k_spin_lock(&g_slots_lock);
+    save_hw_state(slot);
+    k_spin_unlock(&g_slots_lock, key);
+
+    k_mutex_unlock(&g_hw_mutex);
+
+    return rc ? MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED : 0;
+}
+
+int telink_tlx_sha256_finish(mbedtls_sha256_context *ctx,
+                            unsigned char output[32])
+{
+    sha256_slot_t *slot = get_slot(ctx, false);
+    if (!slot || !slot->started) {
+        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
+    }
+
+    k_mutex_lock(&g_hw_mutex, K_FOREVER);
+
+    k_spinlock_key_t key = k_spin_lock(&g_slots_lock);
+    acquire_hw_locked(slot);
+    k_spin_unlock(&g_slots_lock, key);
+
+    int rc = sha256_final(&slot->hw_ctx, output);
+
+    key = k_spin_lock(&g_slots_lock);
+    slot->started = false;
+    if (g_hw_active_slot == slot) {
+        g_hw_active_slot = NULL;
+    }
+    k_spin_unlock(&g_slots_lock, key);
+
+    k_mutex_unlock(&g_hw_mutex);
+
+    return rc ? MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED : 0;
+}
+
+void telink_tlx_sha256_free(mbedtls_sha256_context *ctx)
+{
+    release_slot(ctx);
+}
+
+void telink_tlx_sha256_clone(mbedtls_sha256_context *dst,
+                            const mbedtls_sha256_context *src)
+{
+    sha256_slot_t *src_slot =
+        get_slot((mbedtls_sha256_context *)src, false);
+    if (!src_slot || !src_slot->started) {
+        return;
+    }
+
+    sha256_slot_t *dst_slot = get_slot(dst, true);
+    if (!dst_slot) {
+        return;
+    }
+
+    k_mutex_lock(&g_hw_mutex, K_FOREVER);
+
+    k_spinlock_key_t key = k_spin_lock(&g_slots_lock);
+    if (g_hw_active_slot == src_slot) {
+        save_hw_state(src_slot);
+    }
+
+    memcpy(&dst_slot->hw_ctx,
+           &src_slot->hw_ctx,
+           sizeof(SHA256_CTX));
+    memcpy(dst_slot->iterator,
+           src_slot->iterator,
+           sizeof(dst_slot->iterator));
+    dst_slot->started = true;
+    k_spin_unlock(&g_slots_lock, key);
+
+    k_mutex_unlock(&g_hw_mutex);
+}


### PR DESCRIPTION
MCUBoot image validation takes 5-6 seconds because it uses software SHA256 to hash ~1.5MB of firmware data. Our TLX SoCs have a hardware hash accelerator that can do this much faster.

Original time consumed for verification:
```
[20467.17h.43m.15s.862] *** Booting MCUboot v2.1.0-rc1-233-g346f7374ff44 ***
[20467.17h.43m.15s.862] *** Using Zephyr OS build v3.1.0-rc1-46901-g96fb4638eb6a ***
[20467.17h.43m.15s.862] I: Starting bootloader
...
[20467.17h.43m.21s.064] I: Jumping to the first image slot
[20467.17h.43m.21s.111] *** Booting Zephyr OS build v3.1.0-rc1-46901-g96fb4638eb6a ***
```

### Solution
Use the hardware SHA256 engine for MCUBoot's image validation. Boot time drops to ~2 seconds (3x faster).

The implementation wraps mbedTLS SHA256 functions at link time, similar to how we already handle ECP acceleration. No changes needed to MCUBoot itself.

### How it works
- MCUBoot calls mbedTLS functions: `mbedtls_sha256_init/update/finish`
- Linker redirects these to our wrapper functions
- Wrapper calls Telink's hardware SHA256 driver

### Implementation notes
Uses thread-safe context but has issues with chip-tool commissioning with PM on TLx targets.
Currently works applied only for bootloader.

### Testing
- manually on TL321X with 1.5MB signed firmware of Matter contact-sensor-app
- Jenkins CI pipeline
- Both image slots validated correctly
- Boot time speedup: 5-6s ->~2s:
```
[20474.20h.49m.00s.256] *** Booting MCUboot v2.1.0-rc1-233-g346f7374ff44 ***
[20474.20h.49m.00s.256] *** Using Zephyr OS build v3.1.0-rc1-46901-g96fb4638eb6a ***
[20474.20h.49m.00s.256] I: Starting bootloader
...
[20474.20h.49m.02s.011] I: Jumping to the first image slot
[20474.20h.49m.02s.059] *** Booting Zephyr OS build v3.1.0-rc1-46901-g96fb4638eb6a ***

```
- Image corruption properly detected

Set `CONFIG_TELINK_TLX_MBEDTLS_HW_SHA_ACCELERATION=y` by default in `connectedhomeip/config/telink/app/bootloader.conf`, switched off in Zephyr by default.