### PR TITLE
telink: tlsr9268j: fix PAD wakeup

### DIFF
--- a/hal_v1/tlsr9/drivers/B92/pwm.h
+++ b/hal_v1/tlsr9/drivers/B92/pwm.h
@@ -477,6 +477,7 @@ static inline void pwm_32k_chn_dis(pwm_clk_32k_en_chn_e pwm_32K_en_chn)
 {
     BM_CLR(reg_pwm_mode32k, pwm_32K_en_chn);
 }
+#endif
 
 typedef void (*pwm_set_pin_t)(gpio_func_pin_e pin, gpio_func_e func);
 typedef void (*pwm_set_start_t)(pwm_en_e en);
@@ -485,12 +486,3 @@ typedef void (*pwm_set_stop_t)(pwm_en_e id);
 extern pwm_set_pin_t   pwm_set_pinctrl;
 extern pwm_set_start_t pwm_set_start;
 extern pwm_set_stop_t  pwm_set_stop;
-
-
-
-#endif
-
-
-
-
-

--- a/hal_v2/wrapper/common/tl_sleep.c
+++ b/hal_v2/wrapper/common/tl_sleep.c
@@ -53,6 +53,8 @@ bool tl_suspend(uint32_t wake_stimer_tick)
 	if (state == TL_BT_CONTROLLER_STATE_ACTIVE ||
 		state == TL_BT_CONTROLLER_STATE_STOPPING) {
 		blc_pm_setAppWakeupLowPower(wake_stimer_tick, 1);
+		/* Enable the TIMER and PAD wakeup */
+		blc_pm_setWakeupSource(PM_WAKEUP_TIMER | PM_WAKEUP_PAD);
 		if (!blc_pm_handler()) {
 			rf_set_power_level(tl_tx_pwr_lt[CONFIG_TL_BLE_CTRL_RF_POWER
 			- TL_TX_POWER_MIN]);
@@ -128,6 +130,8 @@ bool tl_deep_sleep(uint32_t wake_stimer_tick)
 	if (state == TL_BT_CONTROLLER_STATE_ACTIVE ||
 		state == TL_BT_CONTROLLER_STATE_STOPPING) {
 		blc_pm_setAppWakeupLowPower(wake_stimer_tick, 1);
+		/* Enable the TIMER and PAD wakeup */
+		blc_pm_setWakeupSource(PM_WAKEUP_TIMER | PM_WAKEUP_PAD);
 		if (!blc_pm_handler()) {
 			rf_set_power_level(tl_tx_pwr_lt[CONFIG_TL_BLE_CTRL_RF_POWER
 			- TL_TX_POWER_MIN]);


### PR DESCRIPTION
 - Set TIMER and PAD wakeup using blc_pm_setWakeupSource .
 - Adjust the pwm(set pin, start, stop) interface location .