### PR TITLE
telink: tlsr9268j: optimize test integration

### DIFF
--- a/hal_v1/tlsr9/drivers/B92/analog.c
+++ b/hal_v1/tlsr9/drivers/B92/analog.c
@@ -445,5 +445,5 @@ _attribute_ram_code_com_sec_optimize_o2_ static void analog_wait(void)
 }
 
 /* Operate analog reg8 by defalut */
-_attribute_data_retention_ analog_read_f analog_read = analog_read_reg8;
-_attribute_data_retention_ analog_write_f analog_write = analog_write_reg8;
+_attribute_data_retention_sec_ analog_read_f analog_read = analog_read_reg8;
+_attribute_data_retention_sec_ analog_write_f analog_write = analog_write_reg8;

--- a/hal_v1/tlsr9/drivers/B92/analog.h
+++ b/hal_v1/tlsr9/drivers/B92/analog.h
@@ -189,5 +189,5 @@ void analog_write_addr_data_dma(dma_chn_e chn, void *pdat, int len);
 typedef unsigned char (*analog_read_f)(unsigned char addr);
 typedef void (*analog_write_f)(unsigned char addr, unsigned char data);
 
-extern _attribute_data_retention_ analog_read_f analog_read;
-extern _attribute_data_retention_ analog_write_f analog_write;
+extern _attribute_data_retention_sec_ analog_read_f analog_read;
+extern _attribute_data_retention_sec_ analog_write_f analog_write;


### PR DESCRIPTION
 - Adjust _attribute_data_retention_ to _attribute_data_retention_sec_ .