### PR TITLE
telink: b92: add i2c and adc interface .

### DIFF
--- a/hal_v1/tlsr9/drivers/B92/adc.c
+++ b/hal_v1/tlsr9/drivers/B92/adc.c
@@ -459,4 +459,17 @@ unsigned short adc_calculate_temperature(unsigned short adc_code)
 	return 564 - ((adc_code * 819)>>13);
 }
 
+/**
+ * @brief      This function open sar_adc power.
+ * @return   none.
+ */
+void adc_power_on_hal(void)
+{
+	analog_write_reg8(areg_adc_pga_ctrl, (analog_read_reg8(areg_adc_pga_ctrl)&(~FLD_SAR_ADC_POWER_DOWN)));
+}
 
+/* Operate analog reg8 by defalut */
+_attribute_data_retention_sec_ adc_vbat_sample_init_f  adc_vbat_sample_init = adc_battery_voltage_sample_init;
+_attribute_data_retention_sec_ adc_power_on_hal_f      adc_vbat_power_on = adc_power_on_hal;
+_attribute_data_retention_sec_ adc_get_code_f          adc_vbat_get_code = adc_get_code;
+_attribute_data_retention_sec_ adc_calculate_voltage_f adc_vbat_calculate_voltage = adc_calculate_voltage;

--- a/hal_v1/tlsr9/drivers/B92/adc.h
+++ b/hal_v1/tlsr9/drivers/B92/adc.h
@@ -457,3 +457,18 @@ unsigned short adc_calculate_voltage(unsigned short adc_code);
  * 			Temp =  564 - ((adc_code * 819)>>13),when Vref = 1.2V, pre_scale = 1.
  */
 unsigned short adc_calculate_temperature(unsigned short adc_code);
+
+/* Operate adc ops by defalut */
+typedef void (*adc_vbat_sample_init_f)(void);
+extern _attribute_data_retention_sec_ adc_vbat_sample_init_f adc_vbat_sample_init;
+
+typedef void (*adc_power_on_hal_f)(void);
+extern _attribute_data_retention_sec_ adc_power_on_hal_f adc_vbat_power_on;
+
+typedef unsigned short (*adc_get_code_f)(void);
+extern _attribute_data_retention_sec_ adc_get_code_f adc_vbat_get_code;
+
+typedef unsigned short (*adc_calculate_voltage_f)(unsigned short adc_code);
+extern _attribute_data_retention_sec_ adc_calculate_voltage_f adc_vbat_calculate_voltage;
+
+

--- a/hal_v1/tlsr9/drivers/B92/i2c.c
+++ b/hal_v1/tlsr9/drivers/B92/i2c.c
@@ -712,4 +712,4 @@ unsigned char i2c1_m_master_write_read(unsigned char id, unsigned char *wr_data,
 	return 1;
 }
 
-
+i2c_set_pin_t i2c_set_p = i2c_set_pin;

--- a/hal_v1/tlsr9/drivers/B92/i2c.h
+++ b/hal_v1/tlsr9/drivers/B92/i2c.h
@@ -754,7 +754,8 @@ unsigned char i2c1_m_master_write_read(unsigned char id, unsigned char *wr_data,
 
 #endif
 
-
+typedef void (*i2c_set_pin_t)(unsigned int sda_pin,unsigned int scl_pin);
+extern i2c_set_pin_t i2c_set_p;
 
 
 


### PR DESCRIPTION
    - add i2c pin set interface .
    - add adc pin set interface .

ddSigned-off-by: Lingzhi Chen <lingzhi.chen@telink-semi.com>