### PR TITLE
hal_v1: tlsr9: crypto: Allow disabling HW SHA

### DIFF
--- a/hal_v1/tlsr9/crypto/Kconfig
+++ b/hal_v1/tlsr9/crypto/Kconfig
@@ -31,7 +31,7 @@ if TELINK_TLX_MBEDTLS_HW_ACCELERATION || TELINK_TLX_TINYCRYPT_HW_ACCELERATION
 
 config TELINK_TLX_SHA_HW_SLOTS
 	int "Telink TLX simultimes HW SHA slots number"
-	range 1 64
+	range 0 64
 	default 4
 
 endif

--- a/hal_v1/tlsr9/crypto/sha_tlx_backend.c
+++ b/hal_v1/tlsr9/crypto/sha_tlx_backend.c
@@ -16,11 +16,10 @@ LOG_MODULE_REGISTER(sha_tlx, CONFIG_TELINK_CRYPTO_BACKEND_LOG_LEVEL);
 extern void telink_tlx_soc_sha_lock(void);
 extern void telink_tlx_soc_sha_unlock(void);
 
-struct {
+static struct {
 	void *lib_ctx;
 	HASH_CTX hw_ctx;
 } telink_tlx_sha_data[CONFIG_TELINK_TLX_SHA_HW_SLOTS];
-static volatile bool telink_tlx_sha_hw_inited;
 
 static int telink_tlx_sha_get_slot(const void *ctx, bool exist)
 {


### PR DESCRIPTION
HW SHA increases RAM usage which can be critical for some projects.
Now it's possible to set CONFIG_TELINK_TLX_SHA_HW_SLOTS to zero as result disable using HW SHA.